### PR TITLE
refactor : 홈 API 응답 시 eTag를 추가합니다.

### DIFF
--- a/src/main/java/usw/suwiki/domain/lecture/controller/LectureController.java
+++ b/src/main/java/usw/suwiki/domain/lecture/controller/LectureController.java
@@ -70,7 +70,8 @@ public class LectureController {
     public ResponseEntity<LectureAndCountResponseForm> findAllLectureApi(
         @RequestParam(required = false) String option,
         @RequestParam(required = false) Integer page,
-        @RequestParam(required = false) String majorType) {
+        @RequestParam(required = false) String majorType
+    ) {
 
         LectureFindOption findOption = new LectureFindOption(option, page, majorType);
         LectureAndCountResponseForm response = lectureService.readAllLecture(findOption);
@@ -81,7 +82,8 @@ public class LectureController {
     @GetMapping
     public ResponseEntity<ResponseForm> findLectureByLectureId(
         @RequestParam Long lectureId,
-        @RequestHeader String Authorization) {
+        @RequestHeader String Authorization
+    ) {
 
         if (jwtAgent.getUserIsRestricted(Authorization)) {
             throw new AccountException(USER_RESTRICTED);

--- a/src/main/java/usw/suwiki/global/config/ETagConfig.java
+++ b/src/main/java/usw/suwiki/global/config/ETagConfig.java
@@ -1,0 +1,22 @@
+package usw.suwiki.global.config;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.filter.ShallowEtagHeaderFilter;
+
+@Configuration
+public class ETagConfig {
+
+    @Bean
+    public ShallowEtagHeaderFilter shallowEtagHeaderFilter() {
+        FilterRegistrationBean<ShallowEtagHeaderFilter> filterFilterRegistrationBean = new FilterRegistrationBean<>(
+            new ShallowEtagHeaderFilter()
+        );
+
+        filterFilterRegistrationBean.addUrlPatterns("/lecture/all");
+        filterFilterRegistrationBean.setName("etagFilter");
+        return new ShallowEtagHeaderFilter();
+    }
+
+}


### PR DESCRIPTION
## 🙋 어떤 PR인가요?

## 📝 작업 상세

- Home API Response Header에 eTag를 부여합니다.
- 클라이언트는 Request Header에 `if-None-Match` : `"MD5EtagPayload"`를 넣고 요청하면 현재 캐시의 내용의 신선도를 추적할 수 있습니다.

## 🙏 To Reviewers

#84 보다 먼저 병합되어야합니다.

## 🧐 체크리스트

- [x]  본인을 Assign해주시고, 본인을 제외한 백엔드 개발자를 Reviewer로 지정해주세요.
- [x]  라벨 체크해주세요.
- [x]  .yml 파일 수정 내용이 있다면 공유해주세요!
- [x]  정상동작하는지, 테스트 통과하는지 다시 한번 확인해주세요.
