### PR TITLE
feat: db cleaner 구현 및 timetable update 테스트 반영

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .env
 *.json
 *.DS_Store
+src/main/generated/**
 
 .gradle
 build/

--- a/usw-suwiki-api/usw-suwiki-client-api/src/test/java/usw/suwiki/api/timetable/TimetableControllerTest.java
+++ b/usw-suwiki-api/usw-suwiki-client-api/src/test/java/usw/suwiki/api/timetable/TimetableControllerTest.java
@@ -1,6 +1,7 @@
 package usw.suwiki.api.timetable;
 
 import io.github.hejow.restdocs.document.RestDocument;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -11,9 +12,12 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.transaction.annotation.Transactional;
 import usw.suwiki.comon.test.Tag;
 import usw.suwiki.comon.test.support.WebMvcTestSupport;
 import usw.suwiki.core.secure.TokenAgent;
+import usw.suwiki.core.secure.model.Claim;
+import usw.suwiki.domain.lecture.timetable.Timetable;
 import usw.suwiki.domain.lecture.timetable.TimetableRepository;
 import usw.suwiki.domain.lecture.timetable.dto.TimetableRequest;
 import usw.suwiki.domain.user.User;
@@ -24,12 +28,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static usw.suwiki.comon.test.extension.AssertExtension.expectExceptionJsonPath;
 import static usw.suwiki.core.exception.ExceptionType.INVALID_TIMETABLE_SEMESTER;
 import static usw.suwiki.core.exception.ExceptionType.INVALID_TOKEN;
+import static usw.suwiki.core.exception.ExceptionType.NOT_AN_AUTHOR;
 import static usw.suwiki.core.exception.ExceptionType.PARAMETER_VALIDATION_FAIL;
 
+@Transactional
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class TimetableControllerTest extends WebMvcTestSupport {
   @Autowired
@@ -38,14 +46,21 @@ class TimetableControllerTest extends WebMvcTestSupport {
   private UserRepository userRepository;
   @Autowired
   private TokenAgent tokenAgent;
+  @Autowired
+  private EntityManager entityManager;
+
+  private final String INVALID_ACCESS_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" +
+                                              ".eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ" +
+                                              ".SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
 
   private User user;
+  private Claim claim;
   private String accessToken;
 
   @BeforeEach
   void setup() {
     user = userRepository.save(User.init("loginId", "password", "test@suwiki.kr"));
-    var claim = new UserClaim(user.getLoginId(), user.getRole().name(), user.getRestricted());
+    claim = new UserClaim(user.getLoginId(), user.getRole().name(), user.getRestricted());
 
     accessToken = tokenAgent.createAccessToken(user.getId(), claim);
   }
@@ -56,7 +71,7 @@ class TimetableControllerTest extends WebMvcTestSupport {
     private final String endpoint = "/timetables";
 
     @Test
-    @DisplayName("시간표를 생성한 뒤 유저 아이디로 만든 시간표에 접근할 수 있어야 한다.")
+    @DisplayName("시간표 생성 성공")
     void create_Success_WithoutException() throws Exception {
       // given
       var request = new TimetableRequest.Description(2024, "first", "2024 1학기 시간표");
@@ -100,7 +115,7 @@ class TimetableControllerTest extends WebMvcTestSupport {
       "2019, 1학기 시간표",
       "2024, 엄청긴이름엄청긴이름엄청긴이름엄청긴이름엄청긴이름엄청긴이름엄청긴이름"
     })
-    @DisplayName("시간표를 생성할 때 잘못된 연도나 너무 긴 이름을 넣으면 bean validation 예외가 발생한다.")
+    @DisplayName("시간표 생성 실패 - 잘못된 연도, 긴 이름 입력")
     void create_Fail_ByInvalidRequests(int year, String name) throws Exception {
       // given
       var request = new TimetableRequest.Description(year, "first", name);
@@ -116,9 +131,7 @@ class TimetableControllerTest extends WebMvcTestSupport {
       // then
       result.andExpectAll(
         status().isBadRequest(),
-        jsonPath("$.code").value(PARAMETER_VALIDATION_FAIL.getCode()),
-        jsonPath("$.message").value(PARAMETER_VALIDATION_FAIL.getMessage()),
-        jsonPath("$.status").value(PARAMETER_VALIDATION_FAIL.getStatus())
+        expectExceptionJsonPath(result, PARAMETER_VALIDATION_FAIL)
       );
 
       // docs
@@ -133,7 +146,7 @@ class TimetableControllerTest extends WebMvcTestSupport {
 
     @ParameterizedTest
     @ValueSource(strings = {"one", "third", "spring", "hello"})
-    @DisplayName("시간표를 생성할 때 잘못된 학기가 들어오면 생성에 실패한다.")
+    @DisplayName("시간표 생성 실패 - 잘못된 학기 입력")
     void create_Fail_ByWrongSemesterEntered(String semester) throws Exception {
       // given
       var request = new TimetableRequest.Description(2024, semester, "시간표입니다.");
@@ -149,9 +162,7 @@ class TimetableControllerTest extends WebMvcTestSupport {
       // then
       result.andExpectAll(
         status().isBadRequest(),
-        jsonPath("$.code").value(INVALID_TIMETABLE_SEMESTER.getCode()),
-        jsonPath("$.message").value(INVALID_TIMETABLE_SEMESTER.getMessage()),
-        jsonPath("$.status").value(INVALID_TIMETABLE_SEMESTER.getStatus())
+        expectExceptionJsonPath(result, INVALID_TIMETABLE_SEMESTER)
       );
 
       // docs
@@ -165,17 +176,14 @@ class TimetableControllerTest extends WebMvcTestSupport {
     }
 
     @Test
-    @DisplayName("잘못된 토큰으로 시간표 생성을 요청하면 400 에러를 던진다.")
+    @DisplayName("시간표 생성 실패 - 잘못된 토큰")
     void create_Fail_ByInvalidToken() throws Exception {
       // given
       var request = new TimetableRequest.Description(2024, "first", "2024 1학기 시간표");
-      var invalidToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" +
-                         ".eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ" +
-                         ".SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
 
       // when
       var result = mockMvc.perform(post(endpoint)
-        .header(AUTHORIZATION, invalidToken)
+        .header(AUTHORIZATION, INVALID_ACCESS_TOKEN)
         .content(objectMapper.writeValueAsString(request))
         .contentType(MediaType.APPLICATION_JSON)
         .accept(MediaType.APPLICATION_JSON)
@@ -184,15 +192,194 @@ class TimetableControllerTest extends WebMvcTestSupport {
       // then
       result.andExpectAll(
         status().isBadRequest(),
-        jsonPath("$.code").value(INVALID_TOKEN.getCode()),
-        jsonPath("$.message").value(INVALID_TOKEN.getMessage()),
-        jsonPath("$.status").value(INVALID_TOKEN.getStatus())
+        expectExceptionJsonPath(result, INVALID_TOKEN)
       );
 
       // docs
       result.andDo(
         RestDocument.builder()
           .identifier("create-timetable-fail-invalid-token")
+          .tag(Tag.TIME_TABLE)
+          .result(result)
+          .generateDocs()
+      );
+    }
+  }
+
+  @Nested
+  @DisplayName("시간표 수정 테스트")
+  class UpdateTimetableTest {
+    private final String endpoint = "/timetables/{timetableId}";
+
+    private Timetable timetable;
+
+    @BeforeEach
+    void setup() {
+      timetable = timetableRepository.save(new Timetable(user.getId(), "이전 시간표", 2023, "first"));
+    }
+
+    @Test
+    @DisplayName("시간표 수정 성공")
+    void update_Success_WithoutException() throws Exception {
+      // given
+      var request = new TimetableRequest.Description(2024, "second", "수정된 시간표");
+
+      // when
+      var result = mockMvc.perform(put(endpoint, timetable.getId())
+        .header(AUTHORIZATION, accessToken)
+        .content(objectMapper.writeValueAsString(request))
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON)
+      );
+
+      // then
+      result.andExpectAll(
+        status().isOk(),
+        jsonPath("$.data.success").value(true)
+      );
+
+      entityManager.clear();
+      var timetables = timetableRepository.findAllByUserId(user.getId());
+      assertAll(
+        () -> assertThat(timetables.get(0)).isNotNull(),
+        () -> assertThat(timetables.get(0).getName()).isNotEqualTo(timetable.getName()),
+        () -> assertThat(timetables.get(0).getYear()).isNotEqualTo(timetable.getYear()),
+        () -> assertThat(timetables.get(0).getSemester()).isNotEqualTo(timetable.getSemester())
+      );
+
+      // docs
+      result.andDo(
+        RestDocument.builder()
+          .identifier("update-timetable-success")
+          .summary("[토큰 필요] 시간표 수정 API")
+          .description("시간표 수정 API 입니다. semester에는 [\"FIRST\", \"SECOND\", \"SUMMER\", \"WINTER\"] 만 입력 가능하니다.")
+          .tag(Tag.TIME_TABLE)
+          .result(result)
+          .generateDocs()
+      );
+    }
+
+    @Test
+    @DisplayName("시간표 수정 실패 - 작성자가 아님")
+    void update_Fail_ByNotAuthor() throws Exception {
+      // given
+      var request = new TimetableRequest.Description(2024, "second", "수정된 시간표");
+
+      var anotherUserToken = tokenAgent.createAccessToken(2L, claim);
+
+      // when
+      var result = mockMvc.perform(put(endpoint, timetable.getId())
+        .header(AUTHORIZATION, anotherUserToken)
+        .content(objectMapper.writeValueAsString(request))
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON)
+      );
+
+      // then
+      result.andExpectAll(
+        status().is4xxClientError(),
+        expectExceptionJsonPath(result, NOT_AN_AUTHOR)
+      );
+
+      // docs
+      result.andDo(
+        RestDocument.builder()
+          .identifier("update-timetable-fail-not-author")
+          .tag(Tag.TIME_TABLE)
+          .result(result)
+          .generateDocs()
+      );
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+      "2019, 1학기 시간표",
+      "2024, 엄청긴이름엄청긴이름엄청긴이름엄청긴이름엄청긴이름엄청긴이름엄청긴이름"
+    })
+    @DisplayName("시간표 수정 실패 - 잘못된 연도, 긴 이름 입력")
+    void update_Fail_ByInvalidRequests(int year, String name) throws Exception {
+      // given
+      var request = new TimetableRequest.Description(year, "first", name);
+
+      // when
+      var result = mockMvc.perform(put(endpoint, timetable.getId())
+        .header(AUTHORIZATION, accessToken)
+        .content(objectMapper.writeValueAsString(request))
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON)
+      );
+
+      // then
+      result.andExpectAll(
+        status().isBadRequest(),
+        expectExceptionJsonPath(result, PARAMETER_VALIDATION_FAIL)
+      );
+
+      // docs
+      result.andDo(
+        RestDocument.builder()
+          .identifier("update-timetable-fail-bad-request")
+          .tag(Tag.TIME_TABLE)
+          .result(result)
+          .generateDocs()
+      );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"one", "third", "spring", "hello"})
+    @DisplayName("시간표 수정 실패 - 잘못된 학기 입력")
+    void update_Fail_ByWrongSemesterEntered(String semester) throws Exception {
+      // given
+      var request = new TimetableRequest.Description(2024, semester, "시간표입니다.");
+
+      // when
+      var result = mockMvc.perform(put(endpoint, timetable.getId())
+        .header(AUTHORIZATION, accessToken)
+        .content(objectMapper.writeValueAsString(request))
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON)
+      );
+
+      // then
+      result.andExpectAll(
+        status().isBadRequest(),
+        expectExceptionJsonPath(result, INVALID_TIMETABLE_SEMESTER)
+      );
+
+      // docs
+      result.andDo(
+        RestDocument.builder()
+          .identifier("update-timetable-fail-wrong-semester")
+          .tag(Tag.TIME_TABLE)
+          .result(result)
+          .generateDocs()
+      );
+    }
+
+    @Test
+    @DisplayName("시간표 수정 실패 - 잘못된 토큰")
+    void update_Fail_ByInvalidToken() throws Exception {
+      // given
+      var request = new TimetableRequest.Description(2024, "second", "수정된 시간표");
+
+      // when
+      var result = mockMvc.perform(put(endpoint, timetable.getId())
+        .header(AUTHORIZATION, INVALID_ACCESS_TOKEN)
+        .content(objectMapper.writeValueAsString(request))
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON)
+      );
+
+      // then
+      result.andExpectAll(
+        status().isBadRequest(),
+        expectExceptionJsonPath(result, INVALID_TOKEN)
+      );
+
+      // docs
+      result.andDo(
+        RestDocument.builder()
+          .identifier("update-timetable-fail-invalid-token")
           .tag(Tag.TIME_TABLE)
           .result(result)
           .generateDocs()

--- a/usw-suwiki-auth/usw-suwiki-auth-token/src/main/java/usw/suwiki/auth/token/RefreshToken.java
+++ b/usw-suwiki-auth/usw-suwiki-auth-token/src/main/java/usw/suwiki/auth/token/RefreshToken.java
@@ -39,7 +39,7 @@ public class RefreshToken {
 
   public void validatePayload(String payload) {
     if (!Objects.equals(this.payload, payload)) {
-      throw new AccountException(ExceptionType.TOKEN_IS_BROKEN);
+      throw new AccountException(ExceptionType.INVALID_TOKEN);
     }
   }
 }

--- a/usw-suwiki-auth/usw-suwiki-auth-token/src/main/java/usw/suwiki/auth/token/service/RefreshTokenCRUDService.java
+++ b/usw-suwiki-auth/usw-suwiki-auth-token/src/main/java/usw/suwiki/auth/token/service/RefreshTokenCRUDService.java
@@ -14,24 +14,25 @@ import java.util.Optional;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class RefreshTokenCRUDService {
-    private final RefreshTokenRepository refreshTokenRepository;
+  private final RefreshTokenRepository refreshTokenRepository;
 
-    @Transactional
-    public void save(RefreshToken refreshToken) {
-        refreshTokenRepository.save(refreshToken);
-    }
+  @Transactional
+  public void save(Long userId, String token) {
+    var refreshToken = new RefreshToken(userId, token);
+    refreshTokenRepository.save(refreshToken);
+  }
 
-    @Transactional
-    public void deleteFromUserIdx(Long userIdx) {
-        refreshTokenRepository.deleteByUserIdx(userIdx);
-    }
+  @Transactional
+  public void deleteByUserId(Long userId) {
+    refreshTokenRepository.deleteByUserIdx(userId);
+  }
 
-    public Optional<RefreshToken> loadRefreshTokenFromUserIdx(Long userIdx) {
-        return refreshTokenRepository.findByUserIdx(userIdx);
-    }
+  public Optional<RefreshToken> loadByUserId(Long userId) {
+    return refreshTokenRepository.findByUserIdx(userId);
+  }
 
-    public RefreshToken loadRefreshTokenFromPayload(String payload) {
-        return refreshTokenRepository.findByPayload(payload)
-            .orElseThrow(() -> new AccountException(ExceptionType.TOKEN_IS_BROKEN));
-    }
+  public RefreshToken loadByPayload(String payload) {
+    return refreshTokenRepository.findByPayload(payload)
+      .orElseThrow(() -> new AccountException(ExceptionType.INVALID_TOKEN));
+  }
 }

--- a/usw-suwiki-common/build.gradle
+++ b/usw-suwiki-common/build.gradle
@@ -10,9 +10,11 @@ dependencies {
 
   // test supports
   testFixturesImplementation project(':usw-suwiki-core:usw-suwiki-exception')
+  
   testFixturesImplementation('org.springframework.boot:spring-boot-starter')
   testFixturesImplementation('org.springframework.boot:spring-boot-starter-web')
   testFixturesImplementation('org.springframework.boot:spring-boot-starter-test')
+  testFixturesImplementation('org.springframework.boot:spring-boot-starter-data-jpa')
 
   testFixturesApi("com.epages:restdocs-api-spec-mockmvc:${restdocsApiSpecVersion}")
   testFixturesApi('org.springframework.restdocs:spring-restdocs-mockmvc')

--- a/usw-suwiki-common/src/testFixtures/java/usw/suwiki/comon/test/db/H2DatabaseCleaner.java
+++ b/usw-suwiki-common/src/testFixtures/java/usw/suwiki/comon/test/db/H2DatabaseCleaner.java
@@ -1,0 +1,27 @@
+package usw.suwiki.comon.test.db;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import usw.suwiki.comon.test.support.DatabaseCleaner;
+
+import java.util.Set;
+
+@Component
+class H2DatabaseCleaner implements DatabaseCleaner {
+  private static final String OFF_REFERENTIAL_INTEGRITY = "SET REFERENTIAL_INTEGRITY FALSE";
+  private static final String ON_REFERENTIAL_INTEGRITY = "SET REFERENTIAL_INTEGRITY TRUE";
+  private static final String TRUNCATE = "TRUNCATE TABLE ";
+
+  @PersistenceContext
+  protected EntityManager entityManager;
+
+  @Transactional
+  @Override
+  public void clean(Set<Table> tables) {
+    entityManager.createNativeQuery(OFF_REFERENTIAL_INTEGRITY).executeUpdate();
+    tables.forEach(table -> entityManager.createNativeQuery(TRUNCATE + table.toLow()));
+    entityManager.createNativeQuery(ON_REFERENTIAL_INTEGRITY).executeUpdate();
+  }
+}

--- a/usw-suwiki-common/src/testFixtures/java/usw/suwiki/comon/test/db/Table.java
+++ b/usw-suwiki-common/src/testFixtures/java/usw/suwiki/comon/test/db/Table.java
@@ -1,0 +1,23 @@
+package usw.suwiki.comon.test.db;
+
+public enum Table {
+  // user
+  USERS, USER_ISOLATION, BLACKLIST_DOMAIN, RESTRICTING_USER,
+
+  // post
+  NOTICE, VIEW_EXAM, EXAM_POST, EVALUATE_POST,
+
+  // lecture
+  LECTURE, FAVORITE_MAJOR, LECTURE_SCHEDULE, TIMETABLE, TIMETABLE_CELLS,
+
+  // report
+  EXAM_POST_REPORT, EVALUATE_POST_REPORT,
+
+  // e.t.c
+  API_LOGGER, REFRESH_TOKEN, CONFIRMATION_TOKEN, CLIENT_APP_VERSION,
+  ;
+
+  public String toLow() {
+    return this.name().toLowerCase();
+  }
+}

--- a/usw-suwiki-common/src/testFixtures/java/usw/suwiki/comon/test/extension/AssertExtension.java
+++ b/usw-suwiki-common/src/testFixtures/java/usw/suwiki/comon/test/extension/AssertExtension.java
@@ -3,10 +3,24 @@ package usw.suwiki.comon.test.extension;
 import org.assertj.core.api.ThrowableAssert;
 import org.assertj.core.api.ThrowableAssertAlternative;
 import org.assertj.core.api.ThrowableTypeAssert;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.ResultMatcher;
 import usw.suwiki.core.exception.BaseException;
 import usw.suwiki.core.exception.ExceptionType;
 
+import java.util.Objects;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
 public final class AssertExtension {
+
+  public static ResultMatcher expectExceptionJsonPath(ResultActions resultActions, ExceptionType exceptionType) {
+    return result -> Objects.requireNonNull(resultActions).andExpectAll(
+      jsonPath("$.code").value(exceptionType.getCode()),
+      jsonPath("$.message").value(exceptionType.getMessage()),
+      jsonPath("$.status").value(exceptionType.getStatus())
+    );
+  }
 
   public static CustomThrowableTypeAssert assertThatApplicationException(ExceptionType exceptionType) {
     return new CustomThrowableTypeAssert(BaseException.class, exceptionType);

--- a/usw-suwiki-common/src/testFixtures/java/usw/suwiki/comon/test/support/DatabaseCleaner.java
+++ b/usw-suwiki-common/src/testFixtures/java/usw/suwiki/comon/test/support/DatabaseCleaner.java
@@ -1,0 +1,9 @@
+package usw.suwiki.comon.test.support;
+
+import usw.suwiki.comon.test.db.Table;
+
+import java.util.Set;
+
+public interface DatabaseCleaner {
+  void clean(Set<Table> tables);
+}

--- a/usw-suwiki-common/src/testFixtures/java/usw/suwiki/comon/test/support/WebMvcTestSupport.java
+++ b/usw-suwiki-common/src/testFixtures/java/usw/suwiki/comon/test/support/WebMvcTestSupport.java
@@ -11,6 +11,9 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
+import usw.suwiki.comon.test.db.Table;
+
+import java.util.Set;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
@@ -26,10 +29,21 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 public abstract class WebMvcTestSupport {
   private static final String ANY_END_POINT = "/**";
 
-  protected MockMvc mockMvc;
+  protected final String INVALID_ACCESS_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" +
+                                                ".eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ" +
+                                                ".SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
 
   @Autowired
   protected ObjectMapper objectMapper;
+
+  @Autowired
+  protected DatabaseCleaner databaseCleaner;
+
+  protected MockMvc mockMvc;
+
+  protected abstract Set<Table> targetTables();
+
+  protected abstract void clean();
 
   @BeforeEach
   void setup(

--- a/usw-suwiki-core/usw-suwiki-exception/src/main/java/usw/suwiki/core/advice/GlobalExceptionHandler.java
+++ b/usw-suwiki-core/usw-suwiki-exception/src/main/java/usw/suwiki/core/advice/GlobalExceptionHandler.java
@@ -30,7 +30,7 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(Exception.class)
   @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
   public ErrorResponse handleException(Exception exception) {
-    log.error("[Unexpected Exception] message : {}", exception.getMessage());
+    log.error("[Unexpected Exception] exception : {}, message : {}", exception.getClass().getName(), exception.getMessage());
     // todo: webhook 추가하기
     return ErrorResponse.internal(exception.getMessage());
   }

--- a/usw-suwiki-core/usw-suwiki-exception/src/main/java/usw/suwiki/core/exception/ExceptionType.java
+++ b/usw-suwiki-core/usw-suwiki-exception/src/main/java/usw/suwiki/core/exception/ExceptionType.java
@@ -69,7 +69,7 @@ public enum ExceptionType {
    * Domain : Token
    */
   TOKEN_IS_EXPIRED("TOKEN001", "토큰이 만료되었습니다 다시 로그인 해주세요", UNAUTHORIZED),
-  TOKEN_IS_BROKEN("TOKEN002", "토큰이 유효하지 않습니다.", BAD_REQUEST),
+  INVALID_TOKEN("TOKEN002", "토큰이 유효하지 않습니다.", BAD_REQUEST),
 
   /**
    * Domain : Lecture

--- a/usw-suwiki-core/usw-suwiki-exception/src/main/java/usw/suwiki/core/exception/ExceptionType.java
+++ b/usw-suwiki-core/usw-suwiki-exception/src/main/java/usw/suwiki/core/exception/ExceptionType.java
@@ -106,7 +106,7 @@ public enum ExceptionType {
    * Domain : Timetable
    */
   TIMETABLE_NOT_FOUND("TIMETABLE001", "존재하지 않는 시간표입니다.", NOT_FOUND),
-  TIMETABLE_NOT_AN_AUTHOR("TIMETABLE002", "해당 데이터의 수정 및 삭제는 작성자의 권한입니다.", FORBIDDEN),
+  NOT_AN_AUTHOR("TIMETABLE002", "해당 데이터의 수정 및 삭제는 작성자의 권한입니다.", FORBIDDEN), // todo: 수정 가능한지 확인하기
   INVALID_TIMETABLE_SEMESTER("TIMETABLE010", "유효하지 않은 학기명입니다.", BAD_REQUEST),
 
   TIMETABLE_CELL_NOT_FOUND("TIMETABLE101", "존재하지 않는 시간표 셀입니다.", NOT_FOUND),

--- a/usw-suwiki-core/usw-suwiki-version/src/main/java/usw/suwiki/core/version/v2/ClientAppVersionService.java
+++ b/usw-suwiki-core/usw-suwiki-version/src/main/java/usw/suwiki/core/version/v2/ClientAppVersionService.java
@@ -15,7 +15,7 @@ public class ClientAppVersionService {
   public CheckUpdateMandatoryResponse checkIsUpdateMandatory(String os, int versionCode) {
     ClientOS clientOS = ClientOS.from(os);
 
-    ClientAppVersion clientAppVersion = clientAppVersionRepository.findFirstByOsAndVitalTrueOrderByVersionCodeDesc(clientOS)
+    ClientAppVersion clientAppVersion = clientAppVersionRepository.findFirstByOsAndIsVitalTrueOrderByVersionCodeDesc(clientOS)
       .orElseThrow(() -> new VersionException(ExceptionType.SERVER_ERROR));
 
     return new CheckUpdateMandatoryResponse(clientAppVersion.isUpdateMandatory(clientOS, versionCode));

--- a/usw-suwiki-lecture/usw-suwiki-timetable/src/main/java/usw/suwiki/domain/lecture/timetable/Timetable.java
+++ b/usw-suwiki-lecture/usw-suwiki-timetable/src/main/java/usw/suwiki/domain/lecture/timetable/Timetable.java
@@ -60,7 +60,7 @@ public class Timetable extends BaseEntity {
 
   public void validateAuthor(Long userId) {
     if (!this.userId.equals(userId)) {
-      throw new TimetableException(ExceptionType.TIMETABLE_NOT_AN_AUTHOR);
+      throw new TimetableException(ExceptionType.NOT_AN_AUTHOR);
     }
   }
 

--- a/usw-suwiki-scheduler/src/main/java/usw/suwiki/schedule/user/UserIsolationSchedulingService.java
+++ b/usw-suwiki-scheduler/src/main/java/usw/suwiki/schedule/user/UserIsolationSchedulingService.java
@@ -99,7 +99,7 @@ public class UserIsolationSchedulingService {
     for (User user : userCRUDService.loadUsersLastLoginBetweenStartEnd(startTime, endTime)) {
       Long userIdx = user.getId();
       clearViewExamService.clear(userIdx);
-      refreshTokenCRUDService.deleteFromUserIdx(userIdx);
+      refreshTokenCRUDService.deleteByUserId(userIdx);
       reportService.deleteFromUserIdx(userIdx);
       evaluatePostService.deleteAllByUserId(userIdx);
       examPostCRUDService.deleteFromUserIdx(userIdx);

--- a/usw-suwiki-user/src/main/java/usw/suwiki/domain/user/service/UserBusinessService.java
+++ b/usw-suwiki-user/src/main/java/usw/suwiki/domain/user/service/UserBusinessService.java
@@ -191,13 +191,13 @@ public class UserBusinessService {
 
   public Map<String, String> executeJWTRefreshForWebClient(Cookie requestRefreshCookie) {
     String payload = requestRefreshCookie.getValue();
-    RefreshToken refreshToken = refreshTokenCRUDService.loadRefreshTokenFromPayload(payload);
+    RefreshToken refreshToken = refreshTokenCRUDService.loadByPayload(payload);
     User user = userCRUDService.loadUserFromUserIdx(refreshToken.getUserIdx());
     return refreshUserJWT(user, payload);
   }
 
   public Map<String, String> executeJWTRefreshForMobileClient(String payload) {
-    RefreshToken refreshToken = refreshTokenCRUDService.loadRefreshTokenFromPayload(payload);
+    RefreshToken refreshToken = refreshTokenCRUDService.loadByPayload(payload);
     User user = userCRUDService.loadUserFromUserIdx(refreshToken.getUserIdx());
     return refreshUserJWT(user, refreshToken.getPayload());
   }


### PR DESCRIPTION
## 🙋 어떤 PR인가요?
- test 초기화 cleaner를 구현

## 📝 작업 상세
- `@Transactional`를 사용한 테스트는 실제 동작 시에 보장하지 못하므로 테스트 단에서 어노테이션을 사용하지 않고자 `DatabaseCleaner`를 추가했습니다.
- 테스트용 db가 변경될 가능성이 있으므로 추상화를 적용했습니다.
- `WebMvcTestSupport`에서 추상 메서드로 clean을 사용하도록 작성자가 선택하게끔 구현했습니다. 모든 테스트에 필연적으로 db가 청소될 일이 없다고 생각했고, 필요한 테이블만 truncate하도록 구현했습니다.

## 🙏 To Reviewers

## 🧐 체크리스트

- [x]  본인을 Assign해주시고, 본인을 제외한 백엔드 개발자를 Reviewer로 지정해주세요.
- [x]  라벨 체크해주세요.
- [ ]  .yml 파일 수정 내용이 있다면 공유해주세요!
- [ ]  정상동작하는지, 테스트 통과하는지 다시 한번 확인해주세요.
