### PR TITLE
refactor: 토큰 agent 추상화 컨트롤러 반영, agent 책임 분리, secret provider 추가

### DIFF
--- a/usw-suwiki-api/usw-suwiki-admin-api/src/main/java/usw/suwiki/domain/user/service/AdminBusinessService.java
+++ b/usw-suwiki-api/usw-suwiki-admin-api/src/main/java/usw/suwiki/domain/user/service/AdminBusinessService.java
@@ -3,10 +3,10 @@ package usw.suwiki.domain.user.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import usw.suwiki.auth.core.jwt.JwtAgent;
 import usw.suwiki.core.exception.AccountException;
 import usw.suwiki.core.exception.ExceptionType;
 import usw.suwiki.core.secure.PasswordEncoder;
+import usw.suwiki.core.secure.TokenAgent;
 import usw.suwiki.core.secure.model.Claim;
 import usw.suwiki.domain.evaluatepost.EvaluatePost;
 import usw.suwiki.domain.evaluatepost.service.EvaluatePostService;
@@ -48,7 +48,7 @@ public class AdminBusinessService {
   private final ExamPostCRUDService examPostCRUDService;
   private final EvaluatePostService evaluatePostService;
 
-  private final JwtAgent jwtAgent;
+  private final TokenAgent tokenAgent;
 
   public Map<String, String> executeAdminLogin(LoginForm loginForm) {
     User user = userCRUDService.loadUserFromLoginId(loginForm.loginId());
@@ -59,7 +59,7 @@ public class AdminBusinessService {
         final long totalUserCount = userCount + userIsolationCount;
         Claim claim = new UserClaim(user.getLoginId(), user.getRole().name(), user.getRestricted());
 
-        return adminLoginResponseForm(jwtAgent.createAccessToken(user.getId(), claim), String.valueOf(totalUserCount));
+        return adminLoginResponseForm(tokenAgent.createAccessToken(user.getId(), claim), String.valueOf(totalUserCount));
       }
       throw new AccountException(ExceptionType.USER_RESTRICTED);
     }

--- a/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/evaluate/EvaluatePostController.java
+++ b/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/evaluate/EvaluatePostController.java
@@ -12,11 +12,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-import usw.suwiki.auth.core.jwt.JwtAgent;
 import usw.suwiki.common.pagination.PageOption;
 import usw.suwiki.common.response.ResponseForm;
-import usw.suwiki.core.exception.AccountException;
-import usw.suwiki.core.exception.ExceptionType;
+import usw.suwiki.core.secure.TokenAgent;
 import usw.suwiki.domain.evaluatepost.dto.EvaluatePostRequest;
 import usw.suwiki.domain.evaluatepost.dto.EvaluatePostResponse;
 import usw.suwiki.domain.evaluatepost.service.EvaluatePostService;
@@ -32,7 +30,7 @@ import static usw.suwiki.statistics.log.MonitorOption.EVALUATE_POSTS;
 @RequiredArgsConstructor
 public class EvaluatePostController {
   private final EvaluatePostService evaluatePostService;
-  private final JwtAgent jwtAgent;
+  private final TokenAgent tokenAgent;
 
   @Monitoring(option = EVALUATE_POSTS)
   @GetMapping
@@ -40,14 +38,10 @@ public class EvaluatePostController {
   public EvaluatePostResponse.Details readEvaluatePostsByLectureApi(
     @RequestHeader String Authorization,
     @RequestParam Long lectureId,
-    @RequestParam(required = false) Optional<Integer> page) {
-
-    jwtAgent.validateJwt(Authorization);
-    if (jwtAgent.isRestrictedUser(Authorization)) {
-      throw new AccountException(ExceptionType.USER_RESTRICTED);
-    }
-
-    Long userId = jwtAgent.parseId(Authorization);
+    @RequestParam(required = false) Optional<Integer> page
+  ) {
+    tokenAgent.validateRestrictedUser(Authorization);
+    Long userId = tokenAgent.parseId(Authorization);
     return evaluatePostService.loadAllEvaluatePostsByLectureId(new PageOption(page), userId, lectureId);
   }
 
@@ -59,12 +53,8 @@ public class EvaluatePostController {
     @RequestParam Long lectureId,
     @Valid @RequestBody EvaluatePostRequest.Create request
   ) {
-    jwtAgent.validateJwt(Authorization);
-    if (jwtAgent.isRestrictedUser(Authorization)) {
-      throw new AccountException(ExceptionType.USER_RESTRICTED);
-    }
-
-    Long userId = jwtAgent.parseId(Authorization);
+    tokenAgent.validateRestrictedUser(Authorization);
+    Long userId = tokenAgent.parseId(Authorization);
     evaluatePostService.write(userId, lectureId, request);
 
     return "success";
@@ -78,11 +68,7 @@ public class EvaluatePostController {
     @RequestParam Long evaluateIdx,
     @Valid @RequestBody EvaluatePostRequest.Update request
   ) {
-    jwtAgent.validateJwt(Authorization);
-    if (jwtAgent.isRestrictedUser(Authorization)) {
-      throw new AccountException(ExceptionType.USER_RESTRICTED);
-    }
-
+    tokenAgent.validateRestrictedUser(Authorization);
     evaluatePostService.update(evaluateIdx, request);
     return "success";
   }
@@ -94,12 +80,8 @@ public class EvaluatePostController {
     @RequestHeader String Authorization,
     @RequestParam(required = false) Optional<Integer> page
   ) {
-    jwtAgent.validateJwt(Authorization);
-    if (jwtAgent.isRestrictedUser(Authorization)) {
-      throw new AccountException(ExceptionType.USER_RESTRICTED);
-    }
-
-    Long userId = jwtAgent.parseId(Authorization);
+    tokenAgent.validateRestrictedUser(Authorization);
+    Long userId = tokenAgent.parseId(Authorization);
     return new ResponseForm(evaluatePostService.loadAllEvaluatePostsByUserId(new PageOption(page), userId));
   }
 
@@ -107,12 +89,8 @@ public class EvaluatePostController {
   @DeleteMapping
   @ResponseStatus(OK)
   public String deleteEvaluation(@RequestParam Long evaluateIdx, @RequestHeader String Authorization) {
-    jwtAgent.validateJwt(Authorization);
-    if (jwtAgent.isRestrictedUser(Authorization)) {
-      throw new AccountException(ExceptionType.USER_RESTRICTED);
-    }
-
-    Long userId = jwtAgent.parseId(Authorization);
+    tokenAgent.validateRestrictedUser(Authorization);
+    Long userId = tokenAgent.parseId(Authorization);
     evaluatePostService.deleteEvaluatePost(evaluateIdx, userId);
     return "success";
   }

--- a/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/lecture/LectureController.java
+++ b/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/lecture/LectureController.java
@@ -9,11 +9,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-import usw.suwiki.auth.core.jwt.JwtAgent;
 import usw.suwiki.common.response.ApiResponse;
 import usw.suwiki.common.response.ResponseForm;
-import usw.suwiki.core.exception.AccountException;
-import usw.suwiki.core.exception.ExceptionType;
+import usw.suwiki.core.secure.TokenAgent;
 import usw.suwiki.domain.lecture.dto.LectureResponse;
 import usw.suwiki.domain.lecture.dto.LectureSearchOption;
 import usw.suwiki.domain.lecture.schedule.service.LectureScheduleService;
@@ -29,7 +27,7 @@ import static usw.suwiki.statistics.log.MonitorOption.LECTURE;
 public class LectureController {
   private final LectureService lectureService;
   private final LectureScheduleService lectureScheduleService;
-  private final JwtAgent jwtAgent;
+  private final TokenAgent tokenAgent;
 
   @Monitoring(option = LECTURE)
   @GetMapping("/search")
@@ -79,10 +77,7 @@ public class LectureController {
     @RequestHeader String Authorization,
     @RequestParam Long lectureId
   ) {
-    if (jwtAgent.isRestrictedUser(Authorization)) {
-      throw new AccountException(ExceptionType.USER_RESTRICTED);
-    }
-
+    tokenAgent.validateRestrictedUser(Authorization);
     return new ResponseForm(lectureService.loadLectureDetail(lectureId));
   }
 }

--- a/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/notice/NoticeController.java
+++ b/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/notice/NoticeController.java
@@ -12,11 +12,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-import usw.suwiki.auth.core.jwt.JwtAgent;
 import usw.suwiki.common.pagination.PageOption;
 import usw.suwiki.common.response.ResponseForm;
 import usw.suwiki.core.exception.AccountException;
 import usw.suwiki.core.exception.ExceptionType;
+import usw.suwiki.core.secure.TokenAgent;
 import usw.suwiki.domain.notice.dto.NoticeRequest;
 import usw.suwiki.domain.notice.dto.NoticeResponse;
 import usw.suwiki.domain.notice.service.NoticeService;
@@ -33,7 +33,7 @@ import static usw.suwiki.statistics.log.MonitorOption.NOTICE;
 @RequiredArgsConstructor
 public class NoticeController {
   private final NoticeService noticeService;
-  private final JwtAgent jwtAgent;
+  private final TokenAgent tokenAgent;
 
   @Monitoring(option = NOTICE)
   @GetMapping("/all")
@@ -58,7 +58,7 @@ public class NoticeController {
     @RequestHeader String Authorization,
     @Valid @RequestBody NoticeRequest.Create request
   ) {
-    jwtAgent.validateJwt(Authorization);
+    tokenAgent.validateJwt(Authorization);
     validateAdmin(Authorization);
     noticeService.write(request.getTitle(), request.getContent());
     return "success";
@@ -72,7 +72,7 @@ public class NoticeController {
     @RequestParam Long noticeId,
     @Valid @RequestBody NoticeRequest.Update request
   ) {
-    jwtAgent.validateJwt(Authorization);
+    tokenAgent.validateJwt(Authorization);
     validateAdmin(Authorization);
     noticeService.update(noticeId, request.getTitle(), request.getContent());
 
@@ -86,7 +86,7 @@ public class NoticeController {
     @RequestHeader String Authorization,
     @RequestParam Long noticeId
   ) {
-    jwtAgent.validateJwt(Authorization);
+    tokenAgent.validateJwt(Authorization);
     validateAdmin(Authorization);
     noticeService.delete(noticeId);
 
@@ -94,7 +94,7 @@ public class NoticeController {
   }
 
   private void validateAdmin(String authorization) {
-    if (!(jwtAgent.parseRole(authorization).equals("ADMIN"))) {
+    if (!(tokenAgent.parseRole(authorization).equals("ADMIN"))) {
       throw new AccountException(ExceptionType.USER_RESTRICTED);
     }
   }

--- a/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/report/ReportController.java
+++ b/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/report/ReportController.java
@@ -8,9 +8,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-import usw.suwiki.auth.core.jwt.JwtAgent;
-import usw.suwiki.core.exception.AccountException;
-import usw.suwiki.core.exception.ExceptionType;
+import usw.suwiki.core.secure.TokenAgent;
 import usw.suwiki.domain.evaluatepost.service.EvaluatePostService;
 import usw.suwiki.domain.exampost.service.ExamPostService;
 import usw.suwiki.domain.report.dto.ReportRequest;
@@ -28,7 +26,7 @@ import static usw.suwiki.statistics.log.MonitorOption.USER;
 public class ReportController {
   private final EvaluatePostService evaluatePostService;
   private final ExamPostService examPostService;
-  private final JwtAgent jwtAgent;
+  private final TokenAgent tokenAgent;
 
   @Monitoring(option = USER)
   @PostMapping("/evaluate")
@@ -37,10 +35,8 @@ public class ReportController {
     @RequestHeader String Authorization,
     @Valid @RequestBody ReportRequest.Evaluate request
   ) {
-    if (jwtAgent.isRestrictedUser(Authorization)) {
-      throw new AccountException(ExceptionType.USER_RESTRICTED);
-    }
-    Long reportingUserId = jwtAgent.parseId(Authorization);
+    tokenAgent.validateRestrictedUser(Authorization);
+    Long reportingUserId = tokenAgent.parseId(Authorization);
     evaluatePostService.report(reportingUserId, request.getEvaluateIdx());
     return successFlag();
   }
@@ -52,10 +48,8 @@ public class ReportController {
     @RequestHeader String Authorization,
     @Valid @RequestBody ReportRequest.Exam request
   ) {
-    if (jwtAgent.isRestrictedUser(Authorization)) {
-      throw new AccountException(ExceptionType.USER_RESTRICTED);
-    }
-    Long reportingUserId = jwtAgent.parseId(Authorization);
+    tokenAgent.validateRestrictedUser(Authorization);
+    Long reportingUserId = tokenAgent.parseId(Authorization);
     examPostService.report(reportingUserId, request.getExamIdx());
     return successFlag();
   }

--- a/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/timetable/TimetableController.java
+++ b/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/timetable/TimetableController.java
@@ -13,8 +13,8 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-import usw.suwiki.auth.core.jwt.JwtAgent;
 import usw.suwiki.common.response.ApiResponse;
+import usw.suwiki.core.secure.TokenAgent;
 import usw.suwiki.domain.lecture.timetable.dto.TimetableRequest;
 import usw.suwiki.domain.lecture.timetable.dto.TimetableResponse;
 import usw.suwiki.domain.lecture.timetable.service.TimetableService;
@@ -26,7 +26,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class TimetableController {
   private final TimetableService timetableService;
-  private final JwtAgent jwtAgent;
+  private final TokenAgent tokenAgent;
 
   @PostMapping
   @ResponseStatus(HttpStatus.CREATED)
@@ -34,7 +34,7 @@ public class TimetableController {
     @RequestHeader String authorization,
     @Valid @RequestBody TimetableRequest.Description request
   ) {
-    Long userId = jwtAgent.parseId(authorization);
+    Long userId = tokenAgent.parseId(authorization);
     timetableService.create(userId, request);
     return ApiResponse.success();
   }
@@ -45,7 +45,7 @@ public class TimetableController {
     @RequestHeader String authorization,
     @RequestBody List<TimetableRequest.Bulk> requests
   ) {
-    Long userId = jwtAgent.parseId(authorization);
+    Long userId = tokenAgent.parseId(authorization);
     timetableService.bulkInsert(userId, requests);
     return ApiResponse.success();
   }
@@ -57,7 +57,7 @@ public class TimetableController {
     @RequestHeader String authorization,
     @Valid @RequestBody TimetableRequest.Description request
   ) {
-    Long userId = jwtAgent.parseId(authorization);
+    Long userId = tokenAgent.parseId(authorization);
 
     timetableService.update(userId, timetableId, request);
     return ApiResponse.success();
@@ -69,7 +69,7 @@ public class TimetableController {
     @PathVariable Long timetableId,
     @RequestHeader String authorization
   ) {
-    Long userId = jwtAgent.parseId(authorization);
+    Long userId = tokenAgent.parseId(authorization);
 
     timetableService.delete(userId, timetableId);
     return ApiResponse.success();
@@ -78,7 +78,7 @@ public class TimetableController {
   @GetMapping
   @ResponseStatus(HttpStatus.OK)
   public ApiResponse<List<TimetableResponse.Simple>> getMyAllTimetables(@RequestHeader String authorization) {
-    Long userId = jwtAgent.parseId(authorization);
+    Long userId = tokenAgent.parseId(authorization);
     return ApiResponse.ok(timetableService.getMyAllTimetables(userId));
   }
 
@@ -88,7 +88,7 @@ public class TimetableController {
     @RequestHeader String authorization,
     @PathVariable Long timetableId
   ) {
-    jwtAgent.validateJwt(authorization);
+    tokenAgent.validateJwt(authorization);
     return ApiResponse.ok(timetableService.loadTimetable(timetableId));
   }
 
@@ -99,7 +99,7 @@ public class TimetableController {
     @PathVariable Long timetableId,
     @Valid @RequestBody TimetableRequest.Cell request
   ) {
-    Long userId = jwtAgent.parseId(authorization);
+    Long userId = tokenAgent.parseId(authorization);
     timetableService.addCell(userId, timetableId, request);
     return ApiResponse.success();
   }
@@ -112,7 +112,7 @@ public class TimetableController {
     @PathVariable int cellIdx,
     @Valid @RequestBody TimetableRequest.UpdateCell request
   ) {
-    Long userId = jwtAgent.parseId(authorization);
+    Long userId = tokenAgent.parseId(authorization);
     timetableService.updateCell(userId, timetableId, cellIdx, request);
     return ApiResponse.success();
   }
@@ -124,7 +124,7 @@ public class TimetableController {
     @PathVariable Long timetableId,
     @PathVariable int cellIdx
   ) {
-    Long userId = jwtAgent.parseId(authorization);
+    Long userId = tokenAgent.parseId(authorization);
     timetableService.deleteCell(userId, timetableId, cellIdx);
     return ApiResponse.success();
   }

--- a/usw-suwiki-auth/usw-suwiki-auth-core/src/main/java/usw/suwiki/auth/core/interceptor/JwtInterceptor.java
+++ b/usw-suwiki-auth/usw-suwiki-auth-core/src/main/java/usw/suwiki/auth/core/interceptor/JwtInterceptor.java
@@ -10,9 +10,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 import usw.suwiki.auth.core.annotation.JwtVerify;
-import usw.suwiki.auth.core.jwt.JwtAgent;
 import usw.suwiki.core.exception.AccountException;
 import usw.suwiki.core.exception.ExceptionType;
+import usw.suwiki.core.secure.TokenAgent;
 
 @Slf4j
 @Component
@@ -20,7 +20,7 @@ import usw.suwiki.core.exception.ExceptionType;
 public class JwtInterceptor implements HandlerInterceptor {
   private static final String ADMIN = "ADMIN";
 
-  private final JwtAgent jwtAgent;
+  private final TokenAgent tokenAgent;
 
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
@@ -41,6 +41,6 @@ public class JwtInterceptor implements HandlerInterceptor {
 
   private String extractRole(HttpServletRequest request) {
     String jwt = request.getHeader(HttpHeaders.AUTHORIZATION);
-    return jwtAgent.parseRole(jwt); // validate
+    return tokenAgent.parseRole(jwt);
   }
 }

--- a/usw-suwiki-auth/usw-suwiki-auth-core/src/main/java/usw/suwiki/auth/core/jwt/JwtSecretProvider.java
+++ b/usw-suwiki-auth/usw-suwiki-auth-core/src/main/java/usw/suwiki/auth/core/jwt/JwtSecretProvider.java
@@ -1,0 +1,39 @@
+package usw.suwiki.auth.core.jwt;
+
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtSecretProvider {
+  private final Key key;
+  private final long accessTokenExpireTime;
+  private final long refreshTokenExpireTime;
+
+  public JwtSecretProvider(
+    @Value("${spring.secret-key}") String key,
+    @Value("${jwt.access-duration}") long accessTokenExpireTime,
+    @Value("${jwt.refresh-duration}") long refreshTokenExpireTime
+  ) {
+    final byte[] keyBytes = Decoders.BASE64.decode(key);
+    this.key = Keys.hmacShaKeyFor(keyBytes);
+    this.accessTokenExpireTime = accessTokenExpireTime;
+    this.refreshTokenExpireTime = refreshTokenExpireTime;
+  }
+
+  public Key key() {
+    return this.key;
+  }
+
+  public Date refreshTokenExpireTime() {
+    return new Date(new Date().getTime() + this.refreshTokenExpireTime);
+  }
+
+  public Date accessTokenExpiredTime() {
+    return new Date(new Date().getTime() + this.accessTokenExpireTime);
+  }
+}

--- a/usw-suwiki-auth/usw-suwiki-auth-core/src/main/java/usw/suwiki/auth/core/jwt/RawParser.java
+++ b/usw-suwiki-auth/usw-suwiki-auth-core/src/main/java/usw/suwiki/auth/core/jwt/RawParser.java
@@ -1,0 +1,56 @@
+package usw.suwiki.auth.core.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import org.springframework.stereotype.Component;
+import usw.suwiki.core.exception.AccountException;
+
+import static usw.suwiki.core.exception.ExceptionType.INVALID_TOKEN;
+import static usw.suwiki.core.exception.ExceptionType.LOGIN_REQUIRED;
+import static usw.suwiki.core.exception.ExceptionType.TOKEN_IS_EXPIRED;
+
+@Component
+class RawParser {
+  enum Content {
+    ID, ROLE, RESTRICTED;
+  }
+
+  private final JwtParser parser;
+
+  RawParser(JwtSecretProvider jwtSecretProvider) {
+    this.parser = Jwts.parserBuilder()
+      .setSigningKey(jwtSecretProvider.key())
+      .build();
+  }
+
+  Jws<Claims> validate(String token) {
+    try {
+      return parser.parseClaimsJws(token);
+    } catch (MalformedJwtException | IllegalArgumentException exception) {
+      throw new AccountException(LOGIN_REQUIRED);
+    } catch (ExpiredJwtException exception) {
+      throw new AccountException(TOKEN_IS_EXPIRED);
+    } catch (SignatureException exception) {
+      throw new AccountException(INVALID_TOKEN);
+    }
+  }
+
+  <T> T parse(String jwt, Content content, Class<T> type) {
+    return validate(jwt).getBody()
+      .get(content.name().toLowerCase(), type);
+  }
+
+  boolean isExpired(String jwt) {
+    try {
+      parser.parseClaimsJws(jwt).getBody().getExpiration();
+    } catch (ExpiredJwtException expiredJwtException) {
+      return true;
+    }
+    return false;
+  }
+}

--- a/usw-suwiki-auth/usw-suwiki-auth-token/src/main/java/usw/suwiki/auth/token/RefreshToken.java
+++ b/usw-suwiki-auth/usw-suwiki-auth-token/src/main/java/usw/suwiki/auth/token/RefreshToken.java
@@ -33,8 +33,9 @@ public class RefreshToken {
     this.payload = payload;
   }
 
-  public void reissue(String payload) {
+  public String reissue(String payload) {
     this.payload = payload;
+    return payload;
   }
 
   public void validatePayload(String payload) {

--- a/usw-suwiki-auth/usw-suwiki-auth-token/src/main/java/usw/suwiki/auth/token/service/RefreshTokenService.java
+++ b/usw-suwiki-auth/usw-suwiki-auth-token/src/main/java/usw/suwiki/auth/token/service/RefreshTokenService.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
-public class RefreshTokenCRUDService {
+public class RefreshTokenService {
   private final RefreshTokenRepository refreshTokenRepository;
 
   @Transactional

--- a/usw-suwiki-core/usw-suwiki-secure/src/main/java/usw/suwiki/core/secure/TokenAgent.java
+++ b/usw-suwiki-core/usw-suwiki-secure/src/main/java/usw/suwiki/core/secure/TokenAgent.java
@@ -3,19 +3,17 @@ package usw.suwiki.core.secure;
 import usw.suwiki.core.secure.model.Claim;
 
 public interface TokenAgent {
-  String provideRefreshTokenInLogin(Long userId);
+  String login(Long userId);
 
-  String reissueRefreshToken(String payload);
+  String reissue(String payload);
 
   void validateJwt(String token);
 
   String createAccessToken(Long userId, Claim claim);
 
-  String createRefreshToken(Long userId);
-
   Long parseId(String token);
 
   String parseRole(String token);
 
-  boolean isRestrictedUser(String token);
+  void validateRestrictedUser(String token);
 }

--- a/usw-suwiki-lecture/usw-suwiki-major/src/main/java/usw/suwiki/domain/lecture/major/service/FavoriteMajorServiceV2.java
+++ b/usw-suwiki-lecture/usw-suwiki-major/src/main/java/usw/suwiki/domain/lecture/major/service/FavoriteMajorServiceV2.java
@@ -3,7 +3,6 @@ package usw.suwiki.domain.lecture.major.service;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import usw.suwiki.core.exception.AccountException;
 import usw.suwiki.core.exception.ExceptionType;
 import usw.suwiki.core.exception.FavoriteMajorException;
 import usw.suwiki.core.secure.TokenAgent;
@@ -21,7 +20,7 @@ public class FavoriteMajorServiceV2 {
   private final TokenAgent tokenAgent;
 
   public void save(String authorization, String majorType) {
-    validateRestrictedUser(authorization);
+    tokenAgent.validateRestrictedUser(authorization);
     Long userId = tokenAgent.parseId(authorization);
 
     validateDuplicateFavoriteMajor(userId, majorType);
@@ -36,7 +35,7 @@ public class FavoriteMajorServiceV2 {
   }
 
   public List<String> findAllMajorTypeByUser(String authorization) {
-    validateRestrictedUser(authorization);
+    tokenAgent.validateRestrictedUser(authorization);
     Long userId = tokenAgent.parseId(authorization);
 
     List<FavoriteMajor> favoriteMajors = favoriteMajorRepositoryV2.findAllByUserIdx(userId);
@@ -44,7 +43,7 @@ public class FavoriteMajorServiceV2 {
   }
 
   public void delete(String authorization, String majorType) {
-    validateRestrictedUser(authorization);
+    tokenAgent.validateRestrictedUser(authorization);
     Long userId = tokenAgent.parseId(authorization);
 
     FavoriteMajor favoriteMajor = favoriteMajorRepositoryV2.findByUserIdxAndMajorType(userId, majorType)
@@ -56,11 +55,5 @@ public class FavoriteMajorServiceV2 {
   public void deleteAllFromUserId(Long userId) {
     List<FavoriteMajor> favoriteMajors = favoriteMajorRepositoryV2.findAllByUserIdx(userId);
     favoriteMajorRepositoryV2.deleteAll(favoriteMajors);
-  }
-
-  private void validateRestrictedUser(String authorization) {
-    if (tokenAgent.isRestrictedUser(authorization)) {
-      throw new AccountException(ExceptionType.USER_RESTRICTED);
-    }
   }
 }

--- a/usw-suwiki-scheduler/src/main/java/usw/suwiki/schedule/user/UserIsolationSchedulingService.java
+++ b/usw-suwiki-scheduler/src/main/java/usw/suwiki/schedule/user/UserIsolationSchedulingService.java
@@ -6,7 +6,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import usw.suwiki.auth.token.service.ConfirmationTokenCRUDService;
-import usw.suwiki.auth.token.service.RefreshTokenCRUDService;
+import usw.suwiki.auth.token.service.RefreshTokenService;
 import usw.suwiki.core.mail.EmailSender;
 import usw.suwiki.domain.evaluatepost.service.EvaluatePostService;
 import usw.suwiki.domain.exampost.service.ExamPostCRUDService;
@@ -41,7 +41,7 @@ public class UserIsolationSchedulingService {
   private final EvaluatePostService evaluatePostService;
   private final ExamPostCRUDService examPostCRUDService;
 
-  private final RefreshTokenCRUDService refreshTokenCRUDService;
+  private final RefreshTokenService refreshTokenService;
   private final ConfirmationTokenCRUDService confirmationTokenCRUDService;
 
   @Scheduled(cron = "2 0 0 * * *")
@@ -99,7 +99,7 @@ public class UserIsolationSchedulingService {
     for (User user : userCRUDService.loadUsersLastLoginBetweenStartEnd(startTime, endTime)) {
       Long userIdx = user.getId();
       clearViewExamService.clear(userIdx);
-      refreshTokenCRUDService.deleteByUserId(userIdx);
+      refreshTokenService.deleteByUserId(userIdx);
       reportService.deleteFromUserIdx(userIdx);
       evaluatePostService.deleteAllByUserId(userIdx);
       examPostCRUDService.deleteFromUserIdx(userIdx);


### PR DESCRIPTION
## 🙋 어떤 PR인가요?
오늘도 **제목이 곧 내용**입니다.

## 📝 작업 상세

### 1. 컨트롤러에 Token 관련 추상화 적용, 중복 코드 간소화
기존 컨트롤러에 직접적으로 `JwtAgent`를 의존하던 부분을 분리했습니다.
API 모듈에서는 어차피 인증 모듈을 의존하기 때문에 당장은 변화가 없다고 볼 수 있지만, 추후 인증 모듈을 분리할 때 인증의 모든 모듈을 의존하지 않아도 되게끔 만들 생각입니다.

### 2. JwtAgent 책임 분리
기존에는 해당 객체의 책임이 create과 parse를 모두 담당했습니다. 
특히 parse를 하는 부분에서 반복되는 형태가 많았고 내부적으로만 사용하는 객체(일종의 도메인 서비스)를 만들어 책임을 분리했습니다.

### 3. Secret provider 추가
기존에는 property 값이 너무 강하게 결합된 형태라서 컴포지션으로 분리시켰습니다.

## 🙏 To Reviewers

## 🧐 체크리스트

- [x]  본인을 Assign해주시고, 본인을 제외한 백엔드 개발자를 Reviewer로 지정해주세요.
- [x]  라벨 체크해주세요.
- [x]  .yml 파일 수정 내용이 있다면 공유해주세요!
- [x]  정상동작하는지, 테스트 통과하는지 다시 한번 확인해주세요.
