### PR TITLE
feat: jwt 검증 및 처리 resolver와 interceptor에 위임

### DIFF
--- a/usw-suwiki-api/usw-suwiki-admin-api/src/main/java/usw/suwiki/api/admin/AdminController.java
+++ b/usw-suwiki-api/usw-suwiki-admin-api/src/main/java/usw/suwiki/api/admin/AdminController.java
@@ -6,14 +6,14 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-import usw.suwiki.auth.core.annotation.JwtVerify;
+import usw.suwiki.auth.core.annotation.Authorize;
 import usw.suwiki.domain.report.EvaluatePostReport;
 import usw.suwiki.domain.report.ExamPostReport;
+import usw.suwiki.domain.user.Role;
 import usw.suwiki.domain.user.dto.UserAdminResponseDto;
 import usw.suwiki.domain.user.service.AdminBusinessService;
 import usw.suwiki.statistics.annotation.Monitoring;
@@ -28,7 +28,7 @@ import static usw.suwiki.domain.user.dto.UserAdminRequestDto.ExamPostBlacklistFo
 import static usw.suwiki.domain.user.dto.UserAdminRequestDto.ExamPostNoProblemForm;
 import static usw.suwiki.domain.user.dto.UserAdminRequestDto.ExamPostRestrictForm;
 import static usw.suwiki.domain.user.dto.UserRequestDto.LoginForm;
-import static usw.suwiki.statistics.log.MonitorOption.ADMIN;
+import static usw.suwiki.statistics.log.MonitorTarget.ADMIN;
 
 @RestController
 @RequestMapping("/admin")
@@ -36,106 +36,95 @@ import static usw.suwiki.statistics.log.MonitorOption.ADMIN;
 public class AdminController {
   private final AdminBusinessService adminBusinessService;
 
-  @Monitoring(option = ADMIN)
+  @Monitoring(target = ADMIN)
   @PostMapping("/login")
   @ResponseStatus(OK)
   public Map<String, String> administratorLogin(@Valid @RequestBody LoginForm loginForm) {
-    return adminBusinessService.executeAdminLogin(loginForm);
+    return adminBusinessService.adminLogin(loginForm);
   }
 
-  @JwtVerify(option = "ADMIN")
-  @Monitoring(option = ADMIN)
+  @Authorize(Role.ADMIN)
+  @Monitoring(target = ADMIN)
   @PostMapping("/restrict/evaluate-posts")
   @ResponseStatus(OK)
   public Map<String, Boolean> restrictEvaluatePost(
-    @Valid @RequestHeader String Authorization,
     @Valid @RequestBody EvaluatePostRestrictForm evaluatePostRestrictForm
   ) {
     return adminBusinessService.executeRestrictEvaluatePost(evaluatePostRestrictForm);
   }
 
-  @JwtVerify(option = "ADMIN")
-  @Monitoring(option = ADMIN)
+  @Authorize(Role.ADMIN)
+  @Monitoring(target = ADMIN)
   @PostMapping("/restrict/exam-post")
   @ResponseStatus(OK)
   public Map<String, Boolean> restrictExamPost(
-    @Valid @RequestHeader String Authorization,
     @Valid @RequestBody ExamPostRestrictForm examPostRestrictForm
   ) {
     return adminBusinessService.executeRestrictExamPost(examPostRestrictForm);
   }
 
 
-  @JwtVerify(option = "ADMIN")
-  @Monitoring(option = ADMIN)
+  @Authorize(Role.ADMIN)
+  @Monitoring(target = ADMIN)
   @PostMapping("/blacklist/evaluate-post")
   @ResponseStatus(OK)
   public Map<String, Boolean> banEvaluatePost(
-    @Valid @RequestHeader String Authorization,
     @Valid @RequestBody EvaluatePostBlacklistForm evaluatePostBlacklistForm
   ) {
     return adminBusinessService.executeBlackListEvaluatePost(evaluatePostBlacklistForm);
   }
 
-  @JwtVerify(option = "ADMIN")
-  @Monitoring(option = ADMIN)
+  @Authorize(Role.ADMIN)
+  @Monitoring(target = ADMIN)
   @PostMapping("/blacklist/exam-post")
   @ResponseStatus(OK)
   public Map<String, Boolean> banExamPost(
-    @Valid @RequestHeader String Authorization,
     @Valid @RequestBody ExamPostBlacklistForm examPostBlacklistForm
   ) {
     return adminBusinessService.executeBlackListExamPost(examPostBlacklistForm);
   }
 
-  @JwtVerify(option = "ADMIN")
-  @Monitoring(option = ADMIN)
+  @Authorize(Role.ADMIN)
+  @Monitoring(target = ADMIN)
   @DeleteMapping("/no-problem/evaluate-post")
   @ResponseStatus(OK)
   public Map<String, Boolean> noProblemEvaluatePost(
-    @Valid @RequestHeader String Authorization,
     @Valid @RequestBody EvaluatePostNoProblemForm evaluatePostNoProblemForm
   ) {
     return adminBusinessService.executeNoProblemEvaluatePost(evaluatePostNoProblemForm);
   }
 
-  @JwtVerify(option = "ADMIN") // todo: 통일
-  @Monitoring(option = ADMIN)
+  @Authorize(Role.ADMIN)
+  @Monitoring(target = ADMIN)
   @DeleteMapping("/no-problem/exam-post")
   @ResponseStatus(OK)
   public Map<String, Boolean> noProblemExamPost(
-    @Valid @RequestHeader String Authorization,
     @Valid @RequestBody ExamPostNoProblemForm examPostNoProblemForm
   ) {
     return adminBusinessService.executeNoProblemExamPost(examPostNoProblemForm);
   }
 
-  @JwtVerify(option = "ADMIN")
-  @Monitoring(option = ADMIN)
+  @Authorize(Role.ADMIN)
+  @Monitoring(target = ADMIN)
   @GetMapping("/report/list")
   @ResponseStatus(OK)
-  public UserAdminResponseDto.LoadAllReportedPostForm loadReportedPost(@RequestHeader String Authorization) {
+  public UserAdminResponseDto.LoadAllReportedPostForm loadReportedPost() {
     return adminBusinessService.executeLoadAllReportedPosts();
   }
 
-  @JwtVerify(option = "ADMIN")
-  @Monitoring(option = ADMIN)
+  @Authorize(Role.ADMIN)
+  @Monitoring(target = ADMIN)
   @GetMapping("/report/evaluate/")
   @ResponseStatus(OK)  // todo: domain dependency
-  public EvaluatePostReport loadDetailReportedEvaluatePost(
-    @Valid @RequestHeader String Authorization,
-    @Valid @RequestParam Long target
-  ) {
+  public EvaluatePostReport loadDetailReportedEvaluatePost(@Valid @RequestParam Long target) {
     return adminBusinessService.executeLoadDetailReportedEvaluatePost(target);
   }
 
-  @Monitoring(option = ADMIN)
+  @Authorize(Role.ADMIN)
+  @Monitoring(target = ADMIN)
   @GetMapping("/report/exam/")
   @ResponseStatus(OK)
-  public ExamPostReport loadDetailReportedExamPost(
-    @Valid @RequestHeader String Authorization,
-    @Valid @RequestParam Long target
-  ) {
+  public ExamPostReport loadDetailReportedExamPost(@Valid @RequestParam Long target) {
     return adminBusinessService.executeLoadDetailReportedExamPost(target);
   }
 }

--- a/usw-suwiki-api/usw-suwiki-admin-api/src/main/java/usw/suwiki/api/admin/AdminController.java
+++ b/usw-suwiki-api/usw-suwiki-admin-api/src/main/java/usw/suwiki/api/admin/AdminController.java
@@ -16,7 +16,7 @@ import usw.suwiki.domain.report.ExamPostReport;
 import usw.suwiki.domain.user.Role;
 import usw.suwiki.domain.user.dto.UserAdminResponseDto;
 import usw.suwiki.domain.user.service.AdminBusinessService;
-import usw.suwiki.statistics.annotation.Monitoring;
+import usw.suwiki.statistics.annotation.Statistics;
 
 import java.util.Map;
 
@@ -36,7 +36,7 @@ import static usw.suwiki.statistics.log.MonitorTarget.ADMIN;
 public class AdminController {
   private final AdminBusinessService adminBusinessService;
 
-  @Monitoring(target = ADMIN)
+  @Statistics(target = ADMIN)
   @PostMapping("/login")
   @ResponseStatus(OK)
   public Map<String, String> administratorLogin(@Valid @RequestBody LoginForm loginForm) {
@@ -44,7 +44,7 @@ public class AdminController {
   }
 
   @Authorize(Role.ADMIN)
-  @Monitoring(target = ADMIN)
+  @Statistics(target = ADMIN)
   @PostMapping("/restrict/evaluate-posts")
   @ResponseStatus(OK)
   public Map<String, Boolean> restrictEvaluatePost(
@@ -54,7 +54,7 @@ public class AdminController {
   }
 
   @Authorize(Role.ADMIN)
-  @Monitoring(target = ADMIN)
+  @Statistics(target = ADMIN)
   @PostMapping("/restrict/exam-post")
   @ResponseStatus(OK)
   public Map<String, Boolean> restrictExamPost(
@@ -65,7 +65,7 @@ public class AdminController {
 
 
   @Authorize(Role.ADMIN)
-  @Monitoring(target = ADMIN)
+  @Statistics(target = ADMIN)
   @PostMapping("/blacklist/evaluate-post")
   @ResponseStatus(OK)
   public Map<String, Boolean> banEvaluatePost(
@@ -75,7 +75,7 @@ public class AdminController {
   }
 
   @Authorize(Role.ADMIN)
-  @Monitoring(target = ADMIN)
+  @Statistics(target = ADMIN)
   @PostMapping("/blacklist/exam-post")
   @ResponseStatus(OK)
   public Map<String, Boolean> banExamPost(
@@ -85,7 +85,7 @@ public class AdminController {
   }
 
   @Authorize(Role.ADMIN)
-  @Monitoring(target = ADMIN)
+  @Statistics(target = ADMIN)
   @DeleteMapping("/no-problem/evaluate-post")
   @ResponseStatus(OK)
   public Map<String, Boolean> noProblemEvaluatePost(
@@ -95,7 +95,7 @@ public class AdminController {
   }
 
   @Authorize(Role.ADMIN)
-  @Monitoring(target = ADMIN)
+  @Statistics(target = ADMIN)
   @DeleteMapping("/no-problem/exam-post")
   @ResponseStatus(OK)
   public Map<String, Boolean> noProblemExamPost(
@@ -105,7 +105,7 @@ public class AdminController {
   }
 
   @Authorize(Role.ADMIN)
-  @Monitoring(target = ADMIN)
+  @Statistics(target = ADMIN)
   @GetMapping("/report/list")
   @ResponseStatus(OK)
   public UserAdminResponseDto.LoadAllReportedPostForm loadReportedPost() {
@@ -113,7 +113,7 @@ public class AdminController {
   }
 
   @Authorize(Role.ADMIN)
-  @Monitoring(target = ADMIN)
+  @Statistics(target = ADMIN)
   @GetMapping("/report/evaluate/")
   @ResponseStatus(OK)  // todo: domain dependency
   public EvaluatePostReport loadDetailReportedEvaluatePost(@Valid @RequestParam Long target) {
@@ -121,7 +121,7 @@ public class AdminController {
   }
 
   @Authorize(Role.ADMIN)
-  @Monitoring(target = ADMIN)
+  @Statistics(target = ADMIN)
   @GetMapping("/report/exam/")
   @ResponseStatus(OK)
   public ExamPostReport loadDetailReportedExamPost(@Valid @RequestParam Long target) {

--- a/usw-suwiki-api/usw-suwiki-admin-api/src/main/java/usw/suwiki/api/admin/AdminControllerV2.java
+++ b/usw-suwiki-api/usw-suwiki-admin-api/src/main/java/usw/suwiki/api/admin/AdminControllerV2.java
@@ -6,14 +6,14 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-import usw.suwiki.auth.core.annotation.JwtVerify;
+import usw.suwiki.auth.core.annotation.Authorize;
 import usw.suwiki.domain.report.EvaluatePostReport;
 import usw.suwiki.domain.report.ExamPostReport;
+import usw.suwiki.domain.user.Role;
 import usw.suwiki.domain.user.dto.UserAdminResponseDto;
 import usw.suwiki.domain.user.service.AdminBusinessService;
 import usw.suwiki.statistics.annotation.Monitoring;
@@ -28,7 +28,7 @@ import static usw.suwiki.domain.user.dto.UserAdminRequestDto.ExamPostBlacklistFo
 import static usw.suwiki.domain.user.dto.UserAdminRequestDto.ExamPostNoProblemForm;
 import static usw.suwiki.domain.user.dto.UserAdminRequestDto.ExamPostRestrictForm;
 import static usw.suwiki.domain.user.dto.UserRequestDto.LoginForm;
-import static usw.suwiki.statistics.log.MonitorOption.ADMIN;
+import static usw.suwiki.statistics.log.MonitorTarget.ADMIN;
 
 @RestController
 @RequestMapping("/v2/admin")
@@ -36,101 +36,95 @@ import static usw.suwiki.statistics.log.MonitorOption.ADMIN;
 public class AdminControllerV2 {
   private final AdminBusinessService adminBusinessService;
 
-  @Monitoring(option = ADMIN)
+  @Monitoring(target = ADMIN)
   @PostMapping("/login")
   @ResponseStatus(OK)
   public Map<String, String> administratorLogin(@Valid @RequestBody LoginForm loginForm) {
-    return adminBusinessService.executeAdminLogin(loginForm);
+    return adminBusinessService.adminLogin(loginForm);
   }
 
-  @JwtVerify(option = "ADMIN")
-  @Monitoring(option = ADMIN)
+  @Authorize(Role.ADMIN)
+  @Monitoring(target = ADMIN)
   @PostMapping("/evaluate-posts/restrict")
   @ResponseStatus(OK)
   public Map<String, Boolean> restrictEvaluatePost(
-    @Valid @RequestHeader String Authorization,
     @Valid @RequestBody EvaluatePostRestrictForm evaluatePostRestrictForm
   ) {
     return adminBusinessService.executeRestrictEvaluatePost(evaluatePostRestrictForm);
   }
 
-  @JwtVerify(option = "ADMIN")
+  @Authorize(Role.ADMIN)
   @ResponseStatus(OK)
-  @Monitoring(option = ADMIN)
+  @Monitoring(target = ADMIN)
   @PostMapping("/exam-post/restrict")
   public Map<String, Boolean> restrictExamPost(
-    @Valid @RequestHeader String Authorization,
     @Valid @RequestBody ExamPostRestrictForm examPostRestrictForm
   ) {
     return adminBusinessService.executeRestrictExamPost(examPostRestrictForm);
   }
 
 
-  @JwtVerify(option = "ADMIN")
+  @Authorize(Role.ADMIN)
   @ResponseStatus(OK)
-  @Monitoring(option = ADMIN)
+  @Monitoring(target = ADMIN)
   @PostMapping("/evaluate-post/blacklist")
   public Map<String, Boolean> banEvaluatePost(
-    @Valid @RequestHeader String Authorization,
     @Valid @RequestBody EvaluatePostBlacklistForm evaluatePostBlacklistForm
   ) {
     return adminBusinessService.executeBlackListEvaluatePost(evaluatePostBlacklistForm);
   }
 
-  @JwtVerify(option = "ADMIN")
+  @Authorize(Role.ADMIN)
   @ResponseStatus(OK)
-  @Monitoring(option = ADMIN)
+  @Monitoring(target = ADMIN)
   @PostMapping("/exam-post/blacklist")
   public Map<String, Boolean> banExamPost(
-    @Valid @RequestHeader String Authorization,
     @Valid @RequestBody ExamPostBlacklistForm examPostBlacklistForm
   ) {
     return adminBusinessService.executeBlackListExamPost(examPostBlacklistForm);
   }
 
-  @JwtVerify(option = "ADMIN")
+  @Authorize(Role.ADMIN)
   @ResponseStatus(OK)
-  @Monitoring(option = ADMIN)
+  @Monitoring(target = ADMIN)
   @DeleteMapping("/evaluate-post")
   public Map<String, Boolean> noProblemEvaluatePost(
-    @Valid @RequestHeader String Authorization,
     @Valid @RequestBody EvaluatePostNoProblemForm evaluatePostNoProblemForm
   ) {
     return adminBusinessService.executeNoProblemEvaluatePost(evaluatePostNoProblemForm);
   }
 
-  @JwtVerify(option = "ADMIN")
+  @Authorize(Role.ADMIN)
   @ResponseStatus(OK)
-  @Monitoring(option = ADMIN)
+  @Monitoring(target = ADMIN)
   @DeleteMapping("/exam-post")
   public Map<String, Boolean> noProblemExamPost(
-    @Valid @RequestHeader String Authorization,
     @Valid @RequestBody ExamPostNoProblemForm examPostNoProblemForm
   ) {
     return adminBusinessService.executeNoProblemExamPost(examPostNoProblemForm);
   }
 
-  @JwtVerify(option = "ADMIN")
-  @Monitoring(option = ADMIN)
+  @Authorize(Role.ADMIN)
+  @Monitoring(target = ADMIN)
   @GetMapping("/reported-posts")
   @ResponseStatus(OK)
-  public UserAdminResponseDto.LoadAllReportedPostForm loadReportedPost(@RequestHeader String Authorization) {
+  public UserAdminResponseDto.LoadAllReportedPostForm loadReportedPost() {
     return adminBusinessService.executeLoadAllReportedPosts();
   }
 
-
-  @JwtVerify(option = "ADMIN")
-  @Monitoring(option = ADMIN)
+  @Authorize(Role.ADMIN)
+  @Monitoring(target = ADMIN)
   @GetMapping("/reported-evaluate/")
   @ResponseStatus(OK)
-  public EvaluatePostReport loadDetailReportedEvaluatePost(@RequestHeader String Authorization, @RequestParam Long target) {
+  public EvaluatePostReport loadDetailReportedEvaluatePost(@RequestParam Long target) {
     return adminBusinessService.executeLoadDetailReportedEvaluatePost(target);
   }
 
-  @Monitoring(option = ADMIN)
+  @Authorize(Role.ADMIN)
+  @Monitoring(target = ADMIN)
   @GetMapping("/reported-exam/")
   @ResponseStatus(OK)
-  public ExamPostReport loadDetailReportedExamPost(@RequestHeader String Authorization, @RequestParam Long target) {
+  public ExamPostReport loadDetailReportedExamPost(@RequestParam Long target) {
     return adminBusinessService.executeLoadDetailReportedExamPost(target);
   }
 }

--- a/usw-suwiki-api/usw-suwiki-admin-api/src/main/java/usw/suwiki/api/admin/AdminControllerV2.java
+++ b/usw-suwiki-api/usw-suwiki-admin-api/src/main/java/usw/suwiki/api/admin/AdminControllerV2.java
@@ -16,7 +16,7 @@ import usw.suwiki.domain.report.ExamPostReport;
 import usw.suwiki.domain.user.Role;
 import usw.suwiki.domain.user.dto.UserAdminResponseDto;
 import usw.suwiki.domain.user.service.AdminBusinessService;
-import usw.suwiki.statistics.annotation.Monitoring;
+import usw.suwiki.statistics.annotation.Statistics;
 
 import java.util.Map;
 
@@ -36,7 +36,7 @@ import static usw.suwiki.statistics.log.MonitorTarget.ADMIN;
 public class AdminControllerV2 {
   private final AdminBusinessService adminBusinessService;
 
-  @Monitoring(target = ADMIN)
+  @Statistics(target = ADMIN)
   @PostMapping("/login")
   @ResponseStatus(OK)
   public Map<String, String> administratorLogin(@Valid @RequestBody LoginForm loginForm) {
@@ -44,7 +44,7 @@ public class AdminControllerV2 {
   }
 
   @Authorize(Role.ADMIN)
-  @Monitoring(target = ADMIN)
+  @Statistics(target = ADMIN)
   @PostMapping("/evaluate-posts/restrict")
   @ResponseStatus(OK)
   public Map<String, Boolean> restrictEvaluatePost(
@@ -55,7 +55,7 @@ public class AdminControllerV2 {
 
   @Authorize(Role.ADMIN)
   @ResponseStatus(OK)
-  @Monitoring(target = ADMIN)
+  @Statistics(target = ADMIN)
   @PostMapping("/exam-post/restrict")
   public Map<String, Boolean> restrictExamPost(
     @Valid @RequestBody ExamPostRestrictForm examPostRestrictForm
@@ -66,7 +66,7 @@ public class AdminControllerV2 {
 
   @Authorize(Role.ADMIN)
   @ResponseStatus(OK)
-  @Monitoring(target = ADMIN)
+  @Statistics(target = ADMIN)
   @PostMapping("/evaluate-post/blacklist")
   public Map<String, Boolean> banEvaluatePost(
     @Valid @RequestBody EvaluatePostBlacklistForm evaluatePostBlacklistForm
@@ -76,7 +76,7 @@ public class AdminControllerV2 {
 
   @Authorize(Role.ADMIN)
   @ResponseStatus(OK)
-  @Monitoring(target = ADMIN)
+  @Statistics(target = ADMIN)
   @PostMapping("/exam-post/blacklist")
   public Map<String, Boolean> banExamPost(
     @Valid @RequestBody ExamPostBlacklistForm examPostBlacklistForm
@@ -86,7 +86,7 @@ public class AdminControllerV2 {
 
   @Authorize(Role.ADMIN)
   @ResponseStatus(OK)
-  @Monitoring(target = ADMIN)
+  @Statistics(target = ADMIN)
   @DeleteMapping("/evaluate-post")
   public Map<String, Boolean> noProblemEvaluatePost(
     @Valid @RequestBody EvaluatePostNoProblemForm evaluatePostNoProblemForm
@@ -96,7 +96,7 @@ public class AdminControllerV2 {
 
   @Authorize(Role.ADMIN)
   @ResponseStatus(OK)
-  @Monitoring(target = ADMIN)
+  @Statistics(target = ADMIN)
   @DeleteMapping("/exam-post")
   public Map<String, Boolean> noProblemExamPost(
     @Valid @RequestBody ExamPostNoProblemForm examPostNoProblemForm
@@ -105,7 +105,7 @@ public class AdminControllerV2 {
   }
 
   @Authorize(Role.ADMIN)
-  @Monitoring(target = ADMIN)
+  @Statistics(target = ADMIN)
   @GetMapping("/reported-posts")
   @ResponseStatus(OK)
   public UserAdminResponseDto.LoadAllReportedPostForm loadReportedPost() {
@@ -113,7 +113,7 @@ public class AdminControllerV2 {
   }
 
   @Authorize(Role.ADMIN)
-  @Monitoring(target = ADMIN)
+  @Statistics(target = ADMIN)
   @GetMapping("/reported-evaluate/")
   @ResponseStatus(OK)
   public EvaluatePostReport loadDetailReportedEvaluatePost(@RequestParam Long target) {
@@ -121,7 +121,7 @@ public class AdminControllerV2 {
   }
 
   @Authorize(Role.ADMIN)
-  @Monitoring(target = ADMIN)
+  @Statistics(target = ADMIN)
   @GetMapping("/reported-exam/")
   @ResponseStatus(OK)
   public ExamPostReport loadDetailReportedExamPost(@RequestParam Long target) {

--- a/usw-suwiki-api/usw-suwiki-admin-api/src/main/java/usw/suwiki/domain/user/service/AdminBusinessService.java
+++ b/usw-suwiki-api/usw-suwiki-admin-api/src/main/java/usw/suwiki/domain/user/service/AdminBusinessService.java
@@ -50,7 +50,7 @@ public class AdminBusinessService {
 
   private final TokenAgent tokenAgent;
 
-  public Map<String, String> executeAdminLogin(LoginForm loginForm) {
+  public Map<String, String> adminLogin(LoginForm loginForm) {
     User user = userCRUDService.loadUserFromLoginId(loginForm.loginId());
     if (user.validatePassword(passwordEncoder, loginForm.password())) {
       if (user.isAdmin()) {

--- a/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/auth/ConfirmationTokenControllerV2.java
+++ b/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/auth/ConfirmationTokenControllerV2.java
@@ -11,7 +11,7 @@ import usw.suwiki.auth.token.service.ConfirmationTokenBusinessService;
 import usw.suwiki.statistics.annotation.Monitoring;
 
 import static org.springframework.http.HttpStatus.OK;
-import static usw.suwiki.statistics.log.MonitorOption.USER;
+import static usw.suwiki.statistics.log.MonitorTarget.USER;
 
 @RestController
 @RequestMapping("/v2/confirmation-token")
@@ -19,7 +19,7 @@ import static usw.suwiki.statistics.log.MonitorOption.USER;
 public class ConfirmationTokenControllerV2 {
   private final ConfirmationTokenBusinessService confirmationTokenBusinessService;
 
-  @Monitoring(option = USER)
+  @Monitoring(target = USER)
   @GetMapping(value = "verify", produces = MediaType.TEXT_HTML_VALUE + ";charset=UTF-8")
   @ResponseStatus(OK)
   public String confirmEmail(@RequestParam("token") String token) {

--- a/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/auth/ConfirmationTokenControllerV2.java
+++ b/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/auth/ConfirmationTokenControllerV2.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import usw.suwiki.auth.token.service.ConfirmationTokenBusinessService;
-import usw.suwiki.statistics.annotation.Monitoring;
+import usw.suwiki.statistics.annotation.Statistics;
 
 import static org.springframework.http.HttpStatus.OK;
 import static usw.suwiki.statistics.log.MonitorTarget.USER;
@@ -19,7 +19,7 @@ import static usw.suwiki.statistics.log.MonitorTarget.USER;
 public class ConfirmationTokenControllerV2 {
   private final ConfirmationTokenBusinessService confirmationTokenBusinessService;
 
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @GetMapping(value = "verify", produces = MediaType.TEXT_HTML_VALUE + ";charset=UTF-8")
   @ResponseStatus(OK)
   public String confirmEmail(@RequestParam("token") String token) {

--- a/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/auth/RefreshTokenControllerV2.java
+++ b/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/auth/RefreshTokenControllerV2.java
@@ -17,7 +17,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.springframework.http.HttpStatus.OK;
-import static usw.suwiki.statistics.log.MonitorOption.USER;
+import static usw.suwiki.statistics.log.MonitorTarget.USER;
 
 @RestController
 @RequestMapping("/v2/refreshtoken")
@@ -25,7 +25,7 @@ import static usw.suwiki.statistics.log.MonitorOption.USER;
 public class RefreshTokenControllerV2 {
   private final UserBusinessService userBusinessService;
 
-  @Monitoring(option = USER)
+  @Monitoring(target = USER)
   @PostMapping("/web-client/refresh")
   @ResponseStatus(OK)
   public ResponseForm clientTokenRefresh(
@@ -45,7 +45,7 @@ public class RefreshTokenControllerV2 {
     }});
   }
 
-  @Monitoring(option = USER)
+  @Monitoring(target = USER)
   @PostMapping("/mobile-client/refresh")
   @ResponseStatus(OK)
   public ResponseForm tokenRefresh(@RequestHeader String Authorization) {

--- a/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/auth/RefreshTokenControllerV2.java
+++ b/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/auth/RefreshTokenControllerV2.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import usw.suwiki.common.response.ResponseForm;
 import usw.suwiki.domain.user.service.UserBusinessService;
-import usw.suwiki.statistics.annotation.Monitoring;
+import usw.suwiki.statistics.annotation.Statistics;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -25,7 +25,7 @@ import static usw.suwiki.statistics.log.MonitorTarget.USER;
 public class RefreshTokenControllerV2 {
   private final UserBusinessService userBusinessService;
 
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @PostMapping("/web-client/refresh")
   @ResponseStatus(OK)
   public ResponseForm clientTokenRefresh(
@@ -45,7 +45,7 @@ public class RefreshTokenControllerV2 {
     }});
   }
 
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @PostMapping("/mobile-client/refresh")
   @ResponseStatus(OK)
   public ResponseForm tokenRefresh(@RequestHeader String Authorization) {

--- a/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/evaluate/EvaluatePostController.java
+++ b/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/evaluate/EvaluatePostController.java
@@ -7,14 +7,14 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import usw.suwiki.auth.core.annotation.Authorize;
+import usw.suwiki.auth.core.annotation.Login;
 import usw.suwiki.common.pagination.PageOption;
 import usw.suwiki.common.response.ResponseForm;
-import usw.suwiki.core.secure.TokenAgent;
 import usw.suwiki.domain.evaluatepost.dto.EvaluatePostRequest;
 import usw.suwiki.domain.evaluatepost.dto.EvaluatePostResponse;
 import usw.suwiki.domain.evaluatepost.service.EvaluatePostService;
@@ -23,74 +23,68 @@ import usw.suwiki.statistics.annotation.Monitoring;
 import java.util.Optional;
 
 import static org.springframework.http.HttpStatus.OK;
-import static usw.suwiki.statistics.log.MonitorOption.EVALUATE_POSTS;
+import static usw.suwiki.statistics.log.MonitorTarget.EVALUATE_POSTS;
 
 @RestController
 @RequestMapping(value = "/evaluate-posts")
 @RequiredArgsConstructor
 public class EvaluatePostController {
   private final EvaluatePostService evaluatePostService;
-  private final TokenAgent tokenAgent;
 
-  @Monitoring(option = EVALUATE_POSTS)
+  @Authorize
+  @Monitoring(target = EVALUATE_POSTS)
   @GetMapping
   @ResponseStatus(OK)
   public EvaluatePostResponse.Details readEvaluatePostsByLectureApi(
-    @RequestHeader String Authorization,
+    @Login Long userId,
     @RequestParam Long lectureId,
     @RequestParam(required = false) Optional<Integer> page
   ) {
-    tokenAgent.validateRestrictedUser(Authorization);
-    Long userId = tokenAgent.parseId(Authorization);
     return evaluatePostService.loadAllEvaluatePostsByLectureId(new PageOption(page), userId, lectureId);
   }
 
-  @Monitoring(option = EVALUATE_POSTS)
+  @Authorize
+  @Monitoring(target = EVALUATE_POSTS)
   @PostMapping
   @ResponseStatus(OK)
   public String writeEvaluation(
-    @RequestHeader String Authorization,
+    @Login Long userId,
     @RequestParam Long lectureId,
     @Valid @RequestBody EvaluatePostRequest.Create request
   ) {
-    tokenAgent.validateRestrictedUser(Authorization);
-    Long userId = tokenAgent.parseId(Authorization);
     evaluatePostService.write(userId, lectureId, request);
-
     return "success";
   }
 
-  @Monitoring(option = EVALUATE_POSTS)
+  @Authorize
+  @Monitoring(target = EVALUATE_POSTS)
   @PutMapping
   @ResponseStatus(OK)
   public String updateEvaluation(
-    @RequestHeader String Authorization,
     @RequestParam Long evaluateIdx,
     @Valid @RequestBody EvaluatePostRequest.Update request
   ) {
-    tokenAgent.validateRestrictedUser(Authorization);
-    evaluatePostService.update(evaluateIdx, request);
+    evaluatePostService.update(evaluateIdx, request); // todo: writer에 대한 검증
     return "success";
   }
 
-  @Monitoring(option = EVALUATE_POSTS)
+  @Authorize
+  @Monitoring(target = EVALUATE_POSTS)
   @GetMapping("/written")
   @ResponseStatus(OK)
   public ResponseForm findByUser(
-    @RequestHeader String Authorization,
+    @Login Long userId,
     @RequestParam(required = false) Optional<Integer> page
   ) {
-    tokenAgent.validateRestrictedUser(Authorization);
-    Long userId = tokenAgent.parseId(Authorization);
-    return new ResponseForm(evaluatePostService.loadAllEvaluatePostsByUserId(new PageOption(page), userId));
+    var response = evaluatePostService.loadAllEvaluatePostsByUserId(new PageOption(page), userId);
+    return new ResponseForm(response);
   }
 
-  @Monitoring(option = EVALUATE_POSTS)
+  @Authorize
+  @Monitoring(target = EVALUATE_POSTS)
   @DeleteMapping
   @ResponseStatus(OK)
-  public String deleteEvaluation(@RequestParam Long evaluateIdx, @RequestHeader String Authorization) {
-    tokenAgent.validateRestrictedUser(Authorization);
-    Long userId = tokenAgent.parseId(Authorization);
+  public String deleteEvaluation(@Login Long userId, @RequestParam Long evaluateIdx) {
     evaluatePostService.deleteEvaluatePost(evaluateIdx, userId);
     return "success";
   }

--- a/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/evaluate/EvaluatePostController.java
+++ b/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/evaluate/EvaluatePostController.java
@@ -11,14 +11,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import usw.suwiki.auth.core.annotation.Authenticated;
 import usw.suwiki.auth.core.annotation.Authorize;
-import usw.suwiki.auth.core.annotation.Login;
 import usw.suwiki.common.pagination.PageOption;
 import usw.suwiki.common.response.ResponseForm;
 import usw.suwiki.domain.evaluatepost.dto.EvaluatePostRequest;
 import usw.suwiki.domain.evaluatepost.dto.EvaluatePostResponse;
 import usw.suwiki.domain.evaluatepost.service.EvaluatePostService;
-import usw.suwiki.statistics.annotation.Monitoring;
+import usw.suwiki.statistics.annotation.Statistics;
 
 import java.util.Optional;
 
@@ -32,11 +32,11 @@ public class EvaluatePostController {
   private final EvaluatePostService evaluatePostService;
 
   @Authorize
-  @Monitoring(target = EVALUATE_POSTS)
+  @Statistics(target = EVALUATE_POSTS)
   @GetMapping
   @ResponseStatus(OK)
   public EvaluatePostResponse.Details readEvaluatePostsByLectureApi(
-    @Login Long userId,
+    @Authenticated Long userId,
     @RequestParam Long lectureId,
     @RequestParam(required = false) Optional<Integer> page
   ) {
@@ -44,11 +44,11 @@ public class EvaluatePostController {
   }
 
   @Authorize
-  @Monitoring(target = EVALUATE_POSTS)
+  @Statistics(target = EVALUATE_POSTS)
   @PostMapping
   @ResponseStatus(OK)
   public String writeEvaluation(
-    @Login Long userId,
+    @Authenticated Long userId,
     @RequestParam Long lectureId,
     @Valid @RequestBody EvaluatePostRequest.Create request
   ) {
@@ -57,7 +57,7 @@ public class EvaluatePostController {
   }
 
   @Authorize
-  @Monitoring(target = EVALUATE_POSTS)
+  @Statistics(target = EVALUATE_POSTS)
   @PutMapping
   @ResponseStatus(OK)
   public String updateEvaluation(
@@ -69,11 +69,11 @@ public class EvaluatePostController {
   }
 
   @Authorize
-  @Monitoring(target = EVALUATE_POSTS)
+  @Statistics(target = EVALUATE_POSTS)
   @GetMapping("/written")
   @ResponseStatus(OK)
   public ResponseForm findByUser(
-    @Login Long userId,
+    @Authenticated Long userId,
     @RequestParam(required = false) Optional<Integer> page
   ) {
     var response = evaluatePostService.loadAllEvaluatePostsByUserId(new PageOption(page), userId);
@@ -81,10 +81,10 @@ public class EvaluatePostController {
   }
 
   @Authorize
-  @Monitoring(target = EVALUATE_POSTS)
+  @Statistics(target = EVALUATE_POSTS)
   @DeleteMapping
   @ResponseStatus(OK)
-  public String deleteEvaluation(@Login Long userId, @RequestParam Long evaluateIdx) {
+  public String deleteEvaluation(@Authenticated Long userId, @RequestParam Long evaluateIdx) {
     evaluatePostService.deleteEvaluatePost(evaluateIdx, userId);
     return "success";
   }

--- a/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/exam/ExamPostsController.java
+++ b/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/exam/ExamPostsController.java
@@ -11,14 +11,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import usw.suwiki.auth.core.annotation.Authenticated;
 import usw.suwiki.auth.core.annotation.Authorize;
-import usw.suwiki.auth.core.annotation.Login;
 import usw.suwiki.common.pagination.PageOption;
 import usw.suwiki.common.response.ResponseForm;
 import usw.suwiki.domain.exampost.dto.ExamPostRequest;
 import usw.suwiki.domain.exampost.dto.ExamPostResponse;
 import usw.suwiki.domain.exampost.service.ExamPostService;
-import usw.suwiki.statistics.annotation.Monitoring;
+import usw.suwiki.statistics.annotation.Statistics;
 
 import java.util.Optional;
 
@@ -32,11 +32,11 @@ public class ExamPostsController {
   private final ExamPostService examPostService;
 
   @Authorize
-  @Monitoring(target = EXAM_POSTS)
+  @Statistics(target = EXAM_POSTS)
   @GetMapping
   @ResponseStatus(OK)
   public ExamPostResponse.Details readAllExamPosts(
-    @Login Long userId,
+    @Authenticated Long userId,
     @RequestParam Long lectureId,
     @RequestParam(required = false) Optional<Integer> page
   ) {
@@ -44,20 +44,20 @@ public class ExamPostsController {
   }
 
   @Authorize
-  @Monitoring(target = EXAM_POSTS)
+  @Statistics(target = EXAM_POSTS)
   @PostMapping("/purchase")
   @ResponseStatus(OK)
-  public String purchaseExamPost(@Login Long userId, @RequestParam Long lectureId) {
+  public String purchaseExamPost(@Authenticated Long userId, @RequestParam Long lectureId) {
     examPostService.purchaseExamPost(userId, lectureId);
     return "success";
   }
 
   @Authorize
-  @Monitoring(target = EXAM_POSTS)
+  @Statistics(target = EXAM_POSTS)
   @PostMapping
   @ResponseStatus(OK)
   public String writeExamPost(
-    @Login Long userId,
+    @Authenticated Long userId,
     @RequestParam Long lectureId,
     @Valid @RequestBody ExamPostRequest.Create request
   ) {
@@ -66,7 +66,7 @@ public class ExamPostsController {
   }
 
   @Authorize
-  @Monitoring(target = EXAM_POSTS)
+  @Statistics(target = EXAM_POSTS)
   @PutMapping
   @ResponseStatus(OK)
   public String updateExamPost(
@@ -78,11 +78,11 @@ public class ExamPostsController {
   }
 
   @Authorize
-  @Monitoring(target = EXAM_POSTS)
+  @Statistics(target = EXAM_POSTS)
   @GetMapping("/written")
   @ResponseStatus(OK)
   public ResponseForm findExamPostsByUserApi(
-    @Login Long userId,
+    @Authenticated Long userId,
     @RequestParam(required = false) Optional<Integer> page
   ) {
     var response = examPostService.loadAllMyExamPosts(new PageOption(page), userId);
@@ -90,19 +90,19 @@ public class ExamPostsController {
   }
 
   @Authorize
-  @Monitoring(target = EXAM_POSTS)
+  @Statistics(target = EXAM_POSTS)
   @DeleteMapping
   @ResponseStatus(OK)
-  public String deleteExamPosts(@Login Long userId, @RequestParam Long examIdx) {
+  public String deleteExamPosts(@Authenticated Long userId, @RequestParam Long examIdx) {
     examPostService.deleteExamPost(userId, examIdx);
     return "success";
   }
 
   @Authorize
-  @Monitoring(target = EXAM_POSTS)
+  @Statistics(target = EXAM_POSTS)
   @GetMapping("/purchase")
   @ResponseStatus(OK)
-  public ResponseForm readPurchaseHistoryApi(@Login Long userId) {
+  public ResponseForm readPurchaseHistoryApi(@Authenticated Long userId) {
     var response = examPostService.loadPurchasedHistories(userId);
     return new ResponseForm(response);
   }

--- a/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/exam/ExamPostsController.java
+++ b/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/exam/ExamPostsController.java
@@ -7,15 +7,14 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-import usw.suwiki.auth.core.annotation.JwtVerify;
+import usw.suwiki.auth.core.annotation.Authorize;
+import usw.suwiki.auth.core.annotation.Login;
 import usw.suwiki.common.pagination.PageOption;
 import usw.suwiki.common.response.ResponseForm;
-import usw.suwiki.core.secure.TokenAgent;
 import usw.suwiki.domain.exampost.dto.ExamPostRequest;
 import usw.suwiki.domain.exampost.dto.ExamPostResponse;
 import usw.suwiki.domain.exampost.service.ExamPostService;
@@ -24,92 +23,87 @@ import usw.suwiki.statistics.annotation.Monitoring;
 import java.util.Optional;
 
 import static org.springframework.http.HttpStatus.OK;
-import static usw.suwiki.statistics.log.MonitorOption.EXAM_POSTS;
+import static usw.suwiki.statistics.log.MonitorTarget.EXAM_POSTS;
 
 @RestController
 @RequestMapping(value = "/exam-posts")
 @RequiredArgsConstructor
 public class ExamPostsController {
   private final ExamPostService examPostService;
-  private final TokenAgent tokenAgent;
 
-  @Monitoring(option = EXAM_POSTS)
+  @Authorize
+  @Monitoring(target = EXAM_POSTS)
   @GetMapping
   @ResponseStatus(OK)
   public ExamPostResponse.Details readAllExamPosts(
-    @RequestHeader String Authorization,
+    @Login Long userId,
     @RequestParam Long lectureId,
     @RequestParam(required = false) Optional<Integer> page
   ) {
-    tokenAgent.validateRestrictedUser(Authorization);
-    Long userId = tokenAgent.parseId(Authorization);
     return examPostService.loadAllExamPosts(userId, lectureId, new PageOption(page));
   }
 
-  @Monitoring(option = EXAM_POSTS)
+  @Authorize
+  @Monitoring(target = EXAM_POSTS)
   @PostMapping("/purchase")
   @ResponseStatus(OK)
-  public String purchaseExamPost(@RequestHeader String Authorization, @RequestParam Long lectureId) {
-    tokenAgent.validateRestrictedUser(Authorization);
-    Long userId = tokenAgent.parseId(Authorization);
+  public String purchaseExamPost(@Login Long userId, @RequestParam Long lectureId) {
     examPostService.purchaseExamPost(userId, lectureId);
     return "success";
   }
 
-  @Monitoring(option = EXAM_POSTS)
+  @Authorize
+  @Monitoring(target = EXAM_POSTS)
   @PostMapping
   @ResponseStatus(OK)
   public String writeExamPost(
-    @RequestHeader String Authorization,
+    @Login Long userId,
     @RequestParam Long lectureId,
     @Valid @RequestBody ExamPostRequest.Create request
   ) {
-    tokenAgent.validateRestrictedUser(Authorization);
-    Long userIdx = tokenAgent.parseId(Authorization);
-    examPostService.write(userIdx, lectureId, request);
+    examPostService.write(userId, lectureId, request);
     return "success";
   }
 
-  @Monitoring(option = EXAM_POSTS)
+  @Authorize
+  @Monitoring(target = EXAM_POSTS)
   @PutMapping
+  @ResponseStatus(OK)
   public String updateExamPost(
-    @RequestHeader String Authorization,
     @RequestParam Long examIdx,
     @Valid @RequestBody ExamPostRequest.Update request
   ) {
-    tokenAgent.validateRestrictedUser(Authorization);
-    examPostService.update(examIdx, request);
+    examPostService.update(examIdx, request); // todo: writer에 대한 검증
     return "success";
   }
 
-  @JwtVerify
-  @Monitoring(option = EXAM_POSTS)
+  @Authorize
+  @Monitoring(target = EXAM_POSTS)
   @GetMapping("/written")
   @ResponseStatus(OK)
   public ResponseForm findExamPostsByUserApi(
-    @RequestHeader String Authorization,
+    @Login Long userId,
     @RequestParam(required = false) Optional<Integer> page
   ) {
-    Long userIdx = tokenAgent.parseId(Authorization);
-    return new ResponseForm(examPostService.loadAllMyExamPosts(new PageOption(page), userIdx));
+    var response = examPostService.loadAllMyExamPosts(new PageOption(page), userId);
+    return new ResponseForm(response);
   }
 
-  @Monitoring(option = EXAM_POSTS)
+  @Authorize
+  @Monitoring(target = EXAM_POSTS)
   @DeleteMapping
   @ResponseStatus(OK)
-  public String deleteExamPosts(@RequestHeader String Authorization, @RequestParam Long examIdx) {
-    tokenAgent.validateRestrictedUser(Authorization);
-    Long userIdx = tokenAgent.parseId(Authorization);
-    examPostService.deleteExamPost(userIdx, examIdx);
+  public String deleteExamPosts(@Login Long userId, @RequestParam Long examIdx) {
+    examPostService.deleteExamPost(userId, examIdx);
     return "success";
   }
 
-  @Monitoring(option = EXAM_POSTS)
+  @Authorize
+  @Monitoring(target = EXAM_POSTS)
   @GetMapping("/purchase")
   @ResponseStatus(OK)
-  public ResponseForm readPurchaseHistoryApi(@RequestHeader String Authorization) {
-    tokenAgent.validateJwt(Authorization);
-    Long userId = tokenAgent.parseId(Authorization);
-    return new ResponseForm(examPostService.loadPurchasedHistories(userId));
+  public ResponseForm readPurchaseHistoryApi(@Login Long userId) {
+    var response = examPostService.loadPurchasedHistories(userId);
+    return new ResponseForm(response);
   }
 }

--- a/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/lecture/LectureController.java
+++ b/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/lecture/LectureController.java
@@ -4,13 +4,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import usw.suwiki.auth.core.annotation.Authorize;
 import usw.suwiki.common.response.ApiResponse;
-import usw.suwiki.core.secure.TokenAgent;
 import usw.suwiki.domain.lecture.dto.LectureResponse;
 import usw.suwiki.domain.lecture.dto.LectureSearchOption;
 import usw.suwiki.domain.lecture.schedule.service.LectureScheduleService;
@@ -18,7 +17,7 @@ import usw.suwiki.domain.lecture.service.LectureService;
 import usw.suwiki.statistics.annotation.CacheStatics;
 import usw.suwiki.statistics.annotation.Monitoring;
 
-import static usw.suwiki.statistics.log.MonitorOption.LECTURE;
+import static usw.suwiki.statistics.log.MonitorTarget.LECTURE;
 
 @RestController
 @RequestMapping(value = "/lecture")
@@ -26,7 +25,6 @@ import static usw.suwiki.statistics.log.MonitorOption.LECTURE;
 public class LectureController {
   private final LectureService lectureService;
   private final LectureScheduleService lectureScheduleService;
-  private final TokenAgent tokenAgent;
 
   @GetMapping("/current/cells/search") // (03.18) 이것만큼은 건들면 안된다.
   @ResponseStatus(HttpStatus.OK)
@@ -41,7 +39,7 @@ public class LectureController {
     return ApiResponse.ok(response);
   }
 
-  @Monitoring(option = LECTURE)
+  @Monitoring(target = LECTURE)
   @GetMapping("/search")
   @ResponseStatus(HttpStatus.OK)
   public LectureResponse.Simples search(
@@ -56,7 +54,7 @@ public class LectureController {
 
   @CacheStatics
   @Cacheable(cacheNames = "lecture")
-  @Monitoring(option = LECTURE)
+  @Monitoring(target = LECTURE)
   @GetMapping("/all")
   @ResponseStatus(HttpStatus.OK)
   public LectureResponse.Simples getMainPageLectures(
@@ -68,14 +66,12 @@ public class LectureController {
     return lectureService.loadAllLectures(findOption);
   }
 
-  @Monitoring(option = LECTURE)
+  @Authorize
+  @Monitoring(target = LECTURE)
   @GetMapping
   @ResponseStatus(HttpStatus.OK)
-  public ApiResponse<LectureResponse.Detail> getDetail(
-    @RequestHeader String Authorization,
-    @RequestParam Long lectureId
-  ) {
-    tokenAgent.validateRestrictedUser(Authorization);
-    return ApiResponse.ok(lectureService.loadLectureDetail(lectureId));
+  public ApiResponse<LectureResponse.Detail> getDetail(@RequestParam Long lectureId) {
+    var response = lectureService.loadLectureDetail(lectureId);
+    return ApiResponse.ok(response);
   }
 }

--- a/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/lecture/LectureController.java
+++ b/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/lecture/LectureController.java
@@ -15,7 +15,7 @@ import usw.suwiki.domain.lecture.dto.LectureSearchOption;
 import usw.suwiki.domain.lecture.schedule.service.LectureScheduleService;
 import usw.suwiki.domain.lecture.service.LectureService;
 import usw.suwiki.statistics.annotation.CacheStatics;
-import usw.suwiki.statistics.annotation.Monitoring;
+import usw.suwiki.statistics.annotation.Statistics;
 
 import static usw.suwiki.statistics.log.MonitorTarget.LECTURE;
 
@@ -39,7 +39,7 @@ public class LectureController {
     return ApiResponse.ok(response);
   }
 
-  @Monitoring(target = LECTURE)
+  @Statistics(target = LECTURE)
   @GetMapping("/search")
   @ResponseStatus(HttpStatus.OK)
   public LectureResponse.Simples search(
@@ -54,7 +54,7 @@ public class LectureController {
 
   @CacheStatics
   @Cacheable(cacheNames = "lecture")
-  @Monitoring(target = LECTURE)
+  @Statistics(target = LECTURE)
   @GetMapping("/all")
   @ResponseStatus(HttpStatus.OK)
   public LectureResponse.Simples getMainPageLectures(
@@ -67,7 +67,7 @@ public class LectureController {
   }
 
   @Authorize
-  @Monitoring(target = LECTURE)
+  @Statistics(target = LECTURE)
   @GetMapping
   @ResponseStatus(HttpStatus.OK)
   public ApiResponse<LectureResponse.Detail> getDetail(@RequestParam Long lectureId) {

--- a/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/notice/NoticeController.java
+++ b/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/notice/NoticeController.java
@@ -7,16 +7,13 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import usw.suwiki.auth.core.annotation.Authorize;
 import usw.suwiki.common.pagination.PageOption;
 import usw.suwiki.common.response.ResponseForm;
-import usw.suwiki.core.exception.AccountException;
-import usw.suwiki.core.exception.ExceptionType;
-import usw.suwiki.core.secure.TokenAgent;
 import usw.suwiki.domain.notice.dto.NoticeRequest;
 import usw.suwiki.domain.notice.dto.NoticeResponse;
 import usw.suwiki.domain.notice.service.NoticeService;
@@ -26,77 +23,56 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.springframework.http.HttpStatus.OK;
-import static usw.suwiki.statistics.log.MonitorOption.NOTICE;
+import static usw.suwiki.domain.user.Role.ADMIN;
+import static usw.suwiki.statistics.log.MonitorTarget.NOTICE;
 
 @RestController
 @RequestMapping(value = "/notice")
 @RequiredArgsConstructor
 public class NoticeController {
   private final NoticeService noticeService;
-  private final TokenAgent tokenAgent;
 
-  @Monitoring(option = NOTICE)
+  @Monitoring(target = NOTICE)
   @GetMapping("/all")
   @ResponseStatus(OK)
-  public ResponseForm findNoticesApi(@RequestParam(required = false) Optional<Integer> page) {
+  public ResponseForm getNotices(@RequestParam(required = false) Optional<Integer> page) {
     List<NoticeResponse.Simple> response = noticeService.getAllNotices(new PageOption(page));
     return new ResponseForm(response);
   }
 
-  @Monitoring(option = NOTICE)
+  @Monitoring(target = NOTICE)
   @GetMapping("/")
   @ResponseStatus(OK)
-  public ResponseForm findNoticeApi(@RequestParam Long noticeId) {
+  public ResponseForm getNotice(@RequestParam Long noticeId) {
     NoticeResponse.Detail response = noticeService.getNotice(noticeId);
     return new ResponseForm(response);
   }
 
-  @Monitoring(option = NOTICE)
+  @Authorize(ADMIN)
+  @Monitoring(target = NOTICE)
   @PostMapping("/")
   @ResponseStatus(OK)
-  public String write(
-    @RequestHeader String Authorization,
-    @Valid @RequestBody NoticeRequest.Create request
-  ) {
-    tokenAgent.validateJwt(Authorization);
-    validateAdmin(Authorization);
+  public String write(@Valid @RequestBody NoticeRequest.Create request) { // todo : admin api
     noticeService.write(request.getTitle(), request.getContent());
     return "success";
   }
 
-  @Monitoring(option = NOTICE)
+  @Authorize(ADMIN)
+  @Monitoring(target = NOTICE)
   @PutMapping("/")
   @ResponseStatus(OK)
-  public String updateNotice(
-    @RequestHeader String Authorization,
-    @RequestParam Long noticeId,
-    @Valid @RequestBody NoticeRequest.Update request
-  ) {
-    tokenAgent.validateJwt(Authorization);
-    validateAdmin(Authorization);
+  public String updateNotice(@RequestParam Long noticeId, @Valid @RequestBody NoticeRequest.Update request) { // todo : admin api
     noticeService.update(noticeId, request.getTitle(), request.getContent());
-
     return "success";
   }
 
-  @Monitoring(option = NOTICE)
+  @Authorize(ADMIN)
+  @Monitoring(target = NOTICE)
   @DeleteMapping("/")
   @ResponseStatus(OK)
-  public String deleteNotice(
-    @RequestHeader String Authorization,
-    @RequestParam Long noticeId
-  ) {
-    tokenAgent.validateJwt(Authorization);
-    validateAdmin(Authorization);
+  public String deleteNotice(@RequestParam Long noticeId) {
     noticeService.delete(noticeId);
-
     return "success";
-  }
-
-  private void validateAdmin(String authorization) {
-    if (!(tokenAgent.parseRole(authorization).equals("ADMIN"))) {
-      throw new AccountException(ExceptionType.USER_RESTRICTED);
-    }
   }
 }
 

--- a/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/notice/NoticeController.java
+++ b/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/notice/NoticeController.java
@@ -17,7 +17,7 @@ import usw.suwiki.common.response.ResponseForm;
 import usw.suwiki.domain.notice.dto.NoticeRequest;
 import usw.suwiki.domain.notice.dto.NoticeResponse;
 import usw.suwiki.domain.notice.service.NoticeService;
-import usw.suwiki.statistics.annotation.Monitoring;
+import usw.suwiki.statistics.annotation.Statistics;
 
 import java.util.List;
 import java.util.Optional;
@@ -32,7 +32,7 @@ import static usw.suwiki.statistics.log.MonitorTarget.NOTICE;
 public class NoticeController {
   private final NoticeService noticeService;
 
-  @Monitoring(target = NOTICE)
+  @Statistics(target = NOTICE)
   @GetMapping("/all")
   @ResponseStatus(OK)
   public ResponseForm getNotices(@RequestParam(required = false) Optional<Integer> page) {
@@ -40,7 +40,7 @@ public class NoticeController {
     return new ResponseForm(response);
   }
 
-  @Monitoring(target = NOTICE)
+  @Statistics(target = NOTICE)
   @GetMapping("/")
   @ResponseStatus(OK)
   public ResponseForm getNotice(@RequestParam Long noticeId) {
@@ -49,7 +49,7 @@ public class NoticeController {
   }
 
   @Authorize(ADMIN)
-  @Monitoring(target = NOTICE)
+  @Statistics(target = NOTICE)
   @PostMapping("/")
   @ResponseStatus(OK)
   public String write(@Valid @RequestBody NoticeRequest.Create request) { // todo : admin api
@@ -58,7 +58,7 @@ public class NoticeController {
   }
 
   @Authorize(ADMIN)
-  @Monitoring(target = NOTICE)
+  @Statistics(target = NOTICE)
   @PutMapping("/")
   @ResponseStatus(OK)
   public String updateNotice(@RequestParam Long noticeId, @Valid @RequestBody NoticeRequest.Update request) { // todo : admin api
@@ -67,7 +67,7 @@ public class NoticeController {
   }
 
   @Authorize(ADMIN)
-  @Monitoring(target = NOTICE)
+  @Statistics(target = NOTICE)
   @DeleteMapping("/")
   @ResponseStatus(OK)
   public String deleteNotice(@RequestParam Long noticeId) {

--- a/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/notice/NoticeControllerV2.java
+++ b/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/notice/NoticeControllerV2.java
@@ -11,7 +11,7 @@ import usw.suwiki.common.pagination.PageOption;
 import usw.suwiki.common.response.ResponseForm;
 import usw.suwiki.domain.notice.dto.NoticeResponse;
 import usw.suwiki.domain.notice.service.NoticeService;
-import usw.suwiki.statistics.annotation.Monitoring;
+import usw.suwiki.statistics.annotation.Statistics;
 
 import java.util.Optional;
 
@@ -24,7 +24,7 @@ import static usw.suwiki.statistics.log.MonitorTarget.NOTICE;
 public class NoticeControllerV2 {
   private final NoticeService noticeService;
 
-  @Monitoring(target = NOTICE)
+  @Statistics(target = NOTICE)
   @GetMapping("/v2")
   @ResponseStatus(OK)
   public ResponseForm getAllNoticesV2(@RequestParam(required = false) Optional<Integer> page) {
@@ -32,7 +32,7 @@ public class NoticeControllerV2 {
     return new ResponseForm(response);
   }
 
-  @Monitoring(target = NOTICE)
+  @Statistics(target = NOTICE)
   @GetMapping("/v2/{noticeId}")
   @ResponseStatus(OK)
   public ResponseForm getNoticeV2(@PathVariable Long noticeId) {

--- a/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/notice/NoticeControllerV2.java
+++ b/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/notice/NoticeControllerV2.java
@@ -13,11 +13,10 @@ import usw.suwiki.domain.notice.dto.NoticeResponse;
 import usw.suwiki.domain.notice.service.NoticeService;
 import usw.suwiki.statistics.annotation.Monitoring;
 
-import java.util.List;
 import java.util.Optional;
 
 import static org.springframework.http.HttpStatus.OK;
-import static usw.suwiki.statistics.log.MonitorOption.NOTICE;
+import static usw.suwiki.statistics.log.MonitorTarget.NOTICE;
 
 @RestController
 @RequestMapping(value = "/notices")
@@ -25,18 +24,18 @@ import static usw.suwiki.statistics.log.MonitorOption.NOTICE;
 public class NoticeControllerV2 {
   private final NoticeService noticeService;
 
-  @Monitoring(option = NOTICE)
+  @Monitoring(target = NOTICE)
   @GetMapping("/v2")
   @ResponseStatus(OK)
-  public ResponseForm findNoticesApiV2(@RequestParam(required = false) Optional<Integer> page) {
-    List<NoticeResponse.Simple> response = noticeService.getAllNotices(new PageOption(page));
+  public ResponseForm getAllNoticesV2(@RequestParam(required = false) Optional<Integer> page) {
+    var response = noticeService.getAllNotices(new PageOption(page));
     return new ResponseForm(response);
   }
 
-  @Monitoring(option = NOTICE)
+  @Monitoring(target = NOTICE)
   @GetMapping("/v2/{noticeId}")
   @ResponseStatus(OK)
-  public ResponseForm findNoticeApiV2(@PathVariable Long noticeId) {
+  public ResponseForm getNoticeV2(@PathVariable Long noticeId) {
     NoticeResponse.Detail response = noticeService.getNotice(noticeId);
     return new ResponseForm(response);
   }

--- a/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/report/ReportController.java
+++ b/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/report/ReportController.java
@@ -4,11 +4,11 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-import usw.suwiki.core.secure.TokenAgent;
+import usw.suwiki.auth.core.annotation.Authorize;
+import usw.suwiki.auth.core.annotation.Login;
 import usw.suwiki.domain.evaluatepost.service.EvaluatePostService;
 import usw.suwiki.domain.exampost.service.ExamPostService;
 import usw.suwiki.domain.report.dto.ReportRequest;
@@ -18,7 +18,7 @@ import java.util.Map;
 
 import static org.springframework.http.HttpStatus.OK;
 import static usw.suwiki.common.response.ApiResponseFactory.successFlag;
-import static usw.suwiki.statistics.log.MonitorOption.USER;
+import static usw.suwiki.statistics.log.MonitorTarget.USER;
 
 @RestController
 @RequestMapping("/user/report")
@@ -26,30 +26,27 @@ import static usw.suwiki.statistics.log.MonitorOption.USER;
 public class ReportController {
   private final EvaluatePostService evaluatePostService;
   private final ExamPostService examPostService;
-  private final TokenAgent tokenAgent;
 
-  @Monitoring(option = USER)
+  @Authorize
+  @Monitoring(target = USER)
   @PostMapping("/evaluate")
   @ResponseStatus(OK)
   public Map<String, Boolean> reportEvaluate(
-    @RequestHeader String Authorization,
+    @Login Long reportingUserId,
     @Valid @RequestBody ReportRequest.Evaluate request
   ) {
-    tokenAgent.validateRestrictedUser(Authorization);
-    Long reportingUserId = tokenAgent.parseId(Authorization);
     evaluatePostService.report(reportingUserId, request.getEvaluateIdx());
     return successFlag();
   }
 
-  @Monitoring(option = USER)
+  @Authorize
+  @Monitoring(target = USER)
   @PostMapping("/exam")
   @ResponseStatus(OK)
   public Map<String, Boolean> reportExam(
-    @RequestHeader String Authorization,
+    @Login Long reportingUserId,
     @Valid @RequestBody ReportRequest.Exam request
   ) {
-    tokenAgent.validateRestrictedUser(Authorization);
-    Long reportingUserId = tokenAgent.parseId(Authorization);
     examPostService.report(reportingUserId, request.getExamIdx());
     return successFlag();
   }

--- a/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/report/ReportController.java
+++ b/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/report/ReportController.java
@@ -7,12 +7,12 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import usw.suwiki.auth.core.annotation.Authenticated;
 import usw.suwiki.auth.core.annotation.Authorize;
-import usw.suwiki.auth.core.annotation.Login;
 import usw.suwiki.domain.evaluatepost.service.EvaluatePostService;
 import usw.suwiki.domain.exampost.service.ExamPostService;
 import usw.suwiki.domain.report.dto.ReportRequest;
-import usw.suwiki.statistics.annotation.Monitoring;
+import usw.suwiki.statistics.annotation.Statistics;
 
 import java.util.Map;
 
@@ -28,11 +28,11 @@ public class ReportController {
   private final ExamPostService examPostService;
 
   @Authorize
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @PostMapping("/evaluate")
   @ResponseStatus(OK)
   public Map<String, Boolean> reportEvaluate(
-    @Login Long reportingUserId,
+    @Authenticated Long reportingUserId,
     @Valid @RequestBody ReportRequest.Evaluate request
   ) {
     evaluatePostService.report(reportingUserId, request.getEvaluateIdx());
@@ -40,11 +40,11 @@ public class ReportController {
   }
 
   @Authorize
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @PostMapping("/exam")
   @ResponseStatus(OK)
   public Map<String, Boolean> reportExam(
-    @Login Long reportingUserId,
+    @Authenticated Long reportingUserId,
     @Valid @RequestBody ReportRequest.Exam request
   ) {
     examPostService.report(reportingUserId, request.getExamIdx());

--- a/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/timetable/TimetableController.java
+++ b/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/timetable/TimetableController.java
@@ -11,8 +11,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import usw.suwiki.auth.core.annotation.Authenticated;
 import usw.suwiki.auth.core.annotation.Authorize;
-import usw.suwiki.auth.core.annotation.Login;
 import usw.suwiki.common.response.ApiResponse;
 import usw.suwiki.domain.lecture.timetable.dto.TimetableRequest;
 import usw.suwiki.domain.lecture.timetable.dto.TimetableResponse;
@@ -32,7 +32,7 @@ public class TimetableController {
   @Authorize
   @PostMapping
   @ResponseStatus(CREATED)
-  public ApiResponse<?> createTimetable(@Login Long userId, @Valid @RequestBody TimetableRequest.Description request) {
+  public ApiResponse<?> createTimetable(@Authenticated Long userId, @Valid @RequestBody TimetableRequest.Description request) {
     timetableService.create(userId, request);
     return ApiResponse.success();
   }
@@ -40,7 +40,7 @@ public class TimetableController {
   @Authorize
   @PostMapping("/bulk")
   @ResponseStatus(OK)
-  public ApiResponse<?> bulkInsert(@Login Long userId, @RequestBody List<TimetableRequest.Bulk> requests) {
+  public ApiResponse<?> bulkInsert(@Authenticated Long userId, @RequestBody List<TimetableRequest.Bulk> requests) {
     timetableService.bulkInsert(userId, requests);
     return ApiResponse.success();
   }
@@ -49,7 +49,7 @@ public class TimetableController {
   @PutMapping("/{timetableId}")
   @ResponseStatus(OK)
   public ApiResponse<?> updateTimetable(
-    @Login Long userId,
+    @Authenticated Long userId,
     @PathVariable Long timetableId,
     @Valid @RequestBody TimetableRequest.Description request
   ) {
@@ -60,7 +60,7 @@ public class TimetableController {
   @Authorize
   @DeleteMapping("/{timetableId}")
   @ResponseStatus(OK)
-  public ApiResponse<?> deleteTimetable(@Login Long userId, @PathVariable Long timetableId) {
+  public ApiResponse<?> deleteTimetable(@Authenticated Long userId, @PathVariable Long timetableId) {
     timetableService.delete(userId, timetableId);
     return ApiResponse.success();
   }
@@ -68,7 +68,7 @@ public class TimetableController {
   @Authorize
   @GetMapping
   @ResponseStatus(OK)
-  public ApiResponse<List<TimetableResponse.Simple>> getMyAllTimetables(@Login Long userId) {
+  public ApiResponse<List<TimetableResponse.Simple>> getMyAllTimetables(@Authenticated Long userId) {
     var response = timetableService.getMyAllTimetables(userId);
     return ApiResponse.ok(response);
   }
@@ -85,7 +85,7 @@ public class TimetableController {
   @PostMapping("/{timetableId}/cells")
   @ResponseStatus(CREATED)
   public ApiResponse<?> insertCell(
-    @Login Long userId,
+    @Authenticated Long userId,
     @PathVariable Long timetableId,
     @Valid @RequestBody TimetableRequest.Cell request
   ) {
@@ -97,7 +97,7 @@ public class TimetableController {
   @PutMapping("/{timetableId}/cells/{cellIdx}")
   @ResponseStatus(OK)
   public ApiResponse<?> updateCell(
-    @Login Long userId,
+    @Authenticated Long userId,
     @PathVariable Long timetableId,
     @PathVariable int cellIdx,
     @Valid @RequestBody TimetableRequest.UpdateCell request
@@ -110,7 +110,7 @@ public class TimetableController {
   @DeleteMapping("/{timetableId}/cells/{cellIdx}")
   @ResponseStatus(OK)
   public ApiResponse<?> deleteCell(
-    @Login Long userId,
+    @Authenticated Long userId,
     @PathVariable Long timetableId,
     @PathVariable int cellIdx
   ) {

--- a/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/timetable/TimetableController.java
+++ b/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/timetable/TimetableController.java
@@ -2,129 +2,118 @@ package usw.suwiki.api.timetable;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import usw.suwiki.auth.core.annotation.Authorize;
+import usw.suwiki.auth.core.annotation.Login;
 import usw.suwiki.common.response.ApiResponse;
-import usw.suwiki.core.secure.TokenAgent;
 import usw.suwiki.domain.lecture.timetable.dto.TimetableRequest;
 import usw.suwiki.domain.lecture.timetable.dto.TimetableResponse;
 import usw.suwiki.domain.lecture.timetable.service.TimetableService;
 
 import java.util.List;
 
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.OK;
+
 @RestController
 @RequestMapping("/timetables")
 @RequiredArgsConstructor
 public class TimetableController {
   private final TimetableService timetableService;
-  private final TokenAgent tokenAgent;
 
+  @Authorize
   @PostMapping
-  @ResponseStatus(HttpStatus.CREATED)
-  public ApiResponse<?> createTimetable(
-    @RequestHeader String authorization,
-    @Valid @RequestBody TimetableRequest.Description request
-  ) {
-    Long userId = tokenAgent.parseId(authorization);
+  @ResponseStatus(CREATED)
+  public ApiResponse<?> createTimetable(@Login Long userId, @Valid @RequestBody TimetableRequest.Description request) {
     timetableService.create(userId, request);
     return ApiResponse.success();
   }
 
+  @Authorize
   @PostMapping("/bulk")
-  @ResponseStatus(HttpStatus.OK)
-  public ApiResponse<?> bulkInsert(
-    @RequestHeader String authorization,
-    @RequestBody List<TimetableRequest.Bulk> requests
-  ) {
-    Long userId = tokenAgent.parseId(authorization);
+  @ResponseStatus(OK)
+  public ApiResponse<?> bulkInsert(@Login Long userId, @RequestBody List<TimetableRequest.Bulk> requests) {
     timetableService.bulkInsert(userId, requests);
     return ApiResponse.success();
   }
 
+  @Authorize
   @PutMapping("/{timetableId}")
-  @ResponseStatus(HttpStatus.OK)
+  @ResponseStatus(OK)
   public ApiResponse<?> updateTimetable(
+    @Login Long userId,
     @PathVariable Long timetableId,
-    @RequestHeader String authorization,
     @Valid @RequestBody TimetableRequest.Description request
   ) {
-    Long userId = tokenAgent.parseId(authorization);
-
     timetableService.update(userId, timetableId, request);
     return ApiResponse.success();
   }
 
+  @Authorize
   @DeleteMapping("/{timetableId}")
-  @ResponseStatus(HttpStatus.OK)
-  public ApiResponse<?> deleteTimetable(
-    @PathVariable Long timetableId,
-    @RequestHeader String authorization
-  ) {
-    Long userId = tokenAgent.parseId(authorization);
-
+  @ResponseStatus(OK)
+  public ApiResponse<?> deleteTimetable(@Login Long userId, @PathVariable Long timetableId) {
     timetableService.delete(userId, timetableId);
     return ApiResponse.success();
   }
 
+  @Authorize
   @GetMapping
-  @ResponseStatus(HttpStatus.OK)
-  public ApiResponse<List<TimetableResponse.Simple>> getMyAllTimetables(@RequestHeader String authorization) {
-    Long userId = tokenAgent.parseId(authorization);
-    return ApiResponse.ok(timetableService.getMyAllTimetables(userId));
+  @ResponseStatus(OK)
+  public ApiResponse<List<TimetableResponse.Simple>> getMyAllTimetables(@Login Long userId) {
+    var response = timetableService.getMyAllTimetables(userId);
+    return ApiResponse.ok(response);
   }
 
+  @Authorize
   @GetMapping("/{timetableId}")
-  @ResponseStatus(HttpStatus.OK)
-  public ApiResponse<TimetableResponse.Detail> getTimetable(
-    @RequestHeader String authorization,
-    @PathVariable Long timetableId
-  ) {
-    tokenAgent.validateJwt(authorization);
-    return ApiResponse.ok(timetableService.loadTimetable(timetableId));
+  @ResponseStatus(OK)
+  public ApiResponse<TimetableResponse.Detail> getTimetable(@PathVariable Long timetableId) {
+    var response = timetableService.loadTimetable(timetableId);
+    return ApiResponse.ok(response);
   }
 
+  @Authorize
   @PostMapping("/{timetableId}/cells")
-  @ResponseStatus(HttpStatus.CREATED)
+  @ResponseStatus(CREATED)
   public ApiResponse<?> insertCell(
-    @RequestHeader String authorization,
+    @Login Long userId,
     @PathVariable Long timetableId,
     @Valid @RequestBody TimetableRequest.Cell request
   ) {
-    Long userId = tokenAgent.parseId(authorization);
     timetableService.addCell(userId, timetableId, request);
     return ApiResponse.success();
   }
 
+  @Authorize
   @PutMapping("/{timetableId}/cells/{cellIdx}")
-  @ResponseStatus(HttpStatus.OK)
+  @ResponseStatus(OK)
   public ApiResponse<?> updateCell(
-    @RequestHeader String authorization,
+    @Login Long userId,
     @PathVariable Long timetableId,
     @PathVariable int cellIdx,
     @Valid @RequestBody TimetableRequest.UpdateCell request
   ) {
-    Long userId = tokenAgent.parseId(authorization);
     timetableService.updateCell(userId, timetableId, cellIdx, request);
     return ApiResponse.success();
   }
 
+  @Authorize
   @DeleteMapping("/{timetableId}/cells/{cellIdx}")
-  @ResponseStatus(HttpStatus.OK)
+  @ResponseStatus(OK)
   public ApiResponse<?> deleteCell(
-    @RequestHeader String authorization,
+    @Login Long userId,
     @PathVariable Long timetableId,
     @PathVariable int cellIdx
   ) {
-    Long userId = tokenAgent.parseId(authorization);
     timetableService.deleteCell(userId, timetableId, cellIdx);
     return ApiResponse.success();
   }

--- a/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/user/BlacklistDomainControllerV2.java
+++ b/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/user/BlacklistDomainControllerV2.java
@@ -1,12 +1,12 @@
 package usw.suwiki.api.user;
 
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import usw.suwiki.auth.core.annotation.Authorize;
+import usw.suwiki.auth.core.annotation.Login;
 import usw.suwiki.domain.user.service.UserBusinessService;
 import usw.suwiki.statistics.annotation.Monitoring;
 
@@ -14,7 +14,7 @@ import java.util.List;
 
 import static org.springframework.http.HttpStatus.OK;
 import static usw.suwiki.domain.user.dto.UserResponseDto.LoadMyBlackListReasonResponseForm;
-import static usw.suwiki.statistics.log.MonitorOption.USER;
+import static usw.suwiki.statistics.log.MonitorTarget.USER;
 
 @RestController
 @RequestMapping("/v2/blacklist")
@@ -22,10 +22,11 @@ import static usw.suwiki.statistics.log.MonitorOption.USER;
 public class BlacklistDomainControllerV2 {
   private final UserBusinessService userBusinessService;
 
-  @Monitoring(option = USER)
+  @Authorize
+  @Monitoring(target = USER)
   @GetMapping("/logs")
   @ResponseStatus(OK)
-  public List<LoadMyBlackListReasonResponseForm> loadBlacklistReason(@Valid @RequestHeader String Authorization) {
-    return userBusinessService.executeLoadBlackListReason(Authorization);
+  public List<LoadMyBlackListReasonResponseForm> loadBlacklistReason(@Login Long userId) {
+    return userBusinessService.executeLoadBlackListReason(userId);
   }
 }

--- a/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/user/BlacklistDomainControllerV2.java
+++ b/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/user/BlacklistDomainControllerV2.java
@@ -5,10 +5,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import usw.suwiki.auth.core.annotation.Authenticated;
 import usw.suwiki.auth.core.annotation.Authorize;
-import usw.suwiki.auth.core.annotation.Login;
 import usw.suwiki.domain.user.service.UserBusinessService;
-import usw.suwiki.statistics.annotation.Monitoring;
+import usw.suwiki.statistics.annotation.Statistics;
 
 import java.util.List;
 
@@ -23,10 +23,10 @@ public class BlacklistDomainControllerV2 {
   private final UserBusinessService userBusinessService;
 
   @Authorize
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @GetMapping("/logs")
   @ResponseStatus(OK)
-  public List<LoadMyBlackListReasonResponseForm> loadBlacklistReason(@Login Long userId) {
+  public List<LoadMyBlackListReasonResponseForm> loadBlacklistReason(@Authenticated Long userId) {
     return userBusinessService.executeLoadBlackListReason(userId);
   }
 }

--- a/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/user/FavoriteMajorController.java
+++ b/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/user/FavoriteMajorController.java
@@ -9,12 +9,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import usw.suwiki.auth.core.annotation.Authenticated;
 import usw.suwiki.auth.core.annotation.Authorize;
-import usw.suwiki.auth.core.annotation.Login;
 import usw.suwiki.common.response.ResponseForm;
 import usw.suwiki.domain.lecture.major.service.FavoriteMajorServiceV2;
 import usw.suwiki.domain.user.dto.FavoriteSaveDto;
-import usw.suwiki.statistics.annotation.Monitoring;
+import usw.suwiki.statistics.annotation.Statistics;
 
 import static org.springframework.http.HttpStatus.OK;
 import static usw.suwiki.statistics.log.MonitorTarget.USER;
@@ -26,28 +26,28 @@ public class FavoriteMajorController {
   private final FavoriteMajorServiceV2 favoriteMajorServiceV2;
 
   @Authorize
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @GetMapping
   @ResponseStatus(OK)
-  public ResponseForm getFavoriteMajors(@Login Long userId) {
+  public ResponseForm getFavoriteMajors(@Authenticated Long userId) {
     var response = favoriteMajorServiceV2.findAllMajorTypeByUser(userId);
     return new ResponseForm(response);
   }
 
   @Authorize
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @PostMapping
   @ResponseStatus(OK)
-  public String create(@Login Long userId, @RequestBody FavoriteSaveDto favoriteSaveDto) {
+  public String create(@Authenticated Long userId, @RequestBody FavoriteSaveDto favoriteSaveDto) {
     favoriteMajorServiceV2.save(userId, favoriteSaveDto.getMajorType());
     return "success";
   }
 
   @Authorize
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @DeleteMapping
   @ResponseStatus(OK)
-  public String delete(@Login Long userId, @RequestParam String majorType) {
+  public String delete(@Authenticated Long userId, @RequestParam String majorType) {
     favoriteMajorServiceV2.delete(userId, majorType);
     return "success";
   }

--- a/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/user/FavoriteMajorController.java
+++ b/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/user/FavoriteMajorController.java
@@ -5,18 +5,19 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import usw.suwiki.auth.core.annotation.Authorize;
+import usw.suwiki.auth.core.annotation.Login;
 import usw.suwiki.common.response.ResponseForm;
 import usw.suwiki.domain.lecture.major.service.FavoriteMajorServiceV2;
 import usw.suwiki.domain.user.dto.FavoriteSaveDto;
 import usw.suwiki.statistics.annotation.Monitoring;
 
 import static org.springframework.http.HttpStatus.OK;
-import static usw.suwiki.statistics.log.MonitorOption.USER;
+import static usw.suwiki.statistics.log.MonitorTarget.USER;
 
 @RestController
 @RequestMapping("/v2/favorite-major")
@@ -24,26 +25,30 @@ import static usw.suwiki.statistics.log.MonitorOption.USER;
 public class FavoriteMajorController {
   private final FavoriteMajorServiceV2 favoriteMajorServiceV2;
 
-  @Monitoring(option = USER)
-  @PostMapping
-  @ResponseStatus(OK)
-  public String create(@RequestHeader String Authorization, @RequestBody FavoriteSaveDto favoriteSaveDto) {
-    favoriteMajorServiceV2.save(Authorization, favoriteSaveDto.getMajorType());
-    return "success";
-  }
-
-  @Monitoring(option = USER)
-  @DeleteMapping
-  @ResponseStatus(OK)
-  public String delete(@RequestHeader String Authorization, @RequestParam String majorType) {
-    favoriteMajorServiceV2.delete(Authorization, majorType);
-    return "success";
-  }
-
-  @Monitoring(option = USER)
+  @Authorize
+  @Monitoring(target = USER)
   @GetMapping
   @ResponseStatus(OK)
-  public ResponseForm retrieve(@RequestHeader String Authorization) {
-    return new ResponseForm(favoriteMajorServiceV2.findAllMajorTypeByUser(Authorization));
+  public ResponseForm getFavoriteMajors(@Login Long userId) {
+    var response = favoriteMajorServiceV2.findAllMajorTypeByUser(userId);
+    return new ResponseForm(response);
+  }
+
+  @Authorize
+  @Monitoring(target = USER)
+  @PostMapping
+  @ResponseStatus(OK)
+  public String create(@Login Long userId, @RequestBody FavoriteSaveDto favoriteSaveDto) {
+    favoriteMajorServiceV2.save(userId, favoriteSaveDto.getMajorType());
+    return "success";
+  }
+
+  @Authorize
+  @Monitoring(target = USER)
+  @DeleteMapping
+  @ResponseStatus(OK)
+  public String delete(@Login Long userId, @RequestParam String majorType) {
+    favoriteMajorServiceV2.delete(userId, majorType);
+    return "success";
   }
 }

--- a/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/user/RestrictingUserControllerV2.java
+++ b/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/user/RestrictingUserControllerV2.java
@@ -5,11 +5,11 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import usw.suwiki.auth.core.annotation.Authenticated;
 import usw.suwiki.auth.core.annotation.Authorize;
-import usw.suwiki.auth.core.annotation.Login;
 import usw.suwiki.common.response.ResponseForm;
 import usw.suwiki.domain.user.service.UserBusinessService;
-import usw.suwiki.statistics.annotation.Monitoring;
+import usw.suwiki.statistics.annotation.Statistics;
 
 import static org.springframework.http.HttpStatus.OK;
 import static usw.suwiki.statistics.log.MonitorTarget.USER;
@@ -21,10 +21,10 @@ public class RestrictingUserControllerV2 {
   private final UserBusinessService userBusinessService;
 
   @Authorize
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @GetMapping
   @ResponseStatus(OK)
-  public ResponseForm loadRestrictedReasons(@Login Long userId) {
+  public ResponseForm loadRestrictedReasons(@Authenticated Long userId) {
     var response = userBusinessService.executeLoadRestrictedReason(userId);
     return ResponseForm.success(response);
   }

--- a/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/user/RestrictingUserControllerV2.java
+++ b/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/user/RestrictingUserControllerV2.java
@@ -1,17 +1,18 @@
 package usw.suwiki.api.user;
 
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import usw.suwiki.auth.core.annotation.Authorize;
+import usw.suwiki.auth.core.annotation.Login;
 import usw.suwiki.common.response.ResponseForm;
 import usw.suwiki.domain.user.service.UserBusinessService;
 import usw.suwiki.statistics.annotation.Monitoring;
 
 import static org.springframework.http.HttpStatus.OK;
-import static usw.suwiki.statistics.log.MonitorOption.USER;
+import static usw.suwiki.statistics.log.MonitorTarget.USER;
 
 @RestController
 @RequestMapping("/v2/user/restricted-reason")
@@ -19,9 +20,12 @@ import static usw.suwiki.statistics.log.MonitorOption.USER;
 public class RestrictingUserControllerV2 {
   private final UserBusinessService userBusinessService;
 
-  @Monitoring(option = USER)
+  @Authorize
+  @Monitoring(target = USER)
+  @GetMapping
   @ResponseStatus(OK)
-  public ResponseForm loadRestrictedReason(@Valid @RequestHeader String Authorization) {
-    return ResponseForm.success(userBusinessService.executeLoadRestrictedReason(Authorization));
+  public ResponseForm loadRestrictedReasons(@Login Long userId) {
+    var response = userBusinessService.executeLoadRestrictedReason(userId);
+    return ResponseForm.success(response);
   }
 }

--- a/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/user/UserController.java
+++ b/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/user/UserController.java
@@ -15,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import usw.suwiki.auth.core.annotation.Authorize;
+import usw.suwiki.auth.core.annotation.Login;
 import usw.suwiki.auth.token.service.ConfirmationTokenBusinessService;
 import usw.suwiki.common.response.ResponseForm;
 import usw.suwiki.core.exception.AccountException;
@@ -40,7 +42,7 @@ import static usw.suwiki.domain.user.dto.UserRequestDto.UserQuitForm;
 import static usw.suwiki.domain.user.dto.UserResponseDto.LoadMyBlackListReasonResponseForm;
 import static usw.suwiki.domain.user.dto.UserResponseDto.LoadMyRestrictedReasonResponseForm;
 import static usw.suwiki.domain.user.dto.UserResponseDto.UserInformationResponseForm;
-import static usw.suwiki.statistics.log.MonitorOption.USER;
+import static usw.suwiki.statistics.log.MonitorTarget.USER;
 
 @RestController
 @RequestMapping("/user")
@@ -49,21 +51,21 @@ public class UserController {
   private final UserBusinessService userBusinessService;
   private final ConfirmationTokenBusinessService confirmationTokenBusinessService;
 
-  @Monitoring(option = USER)
+  @Monitoring(target = USER)
   @PostMapping("/check-id")
   @ResponseStatus(OK)
   public Map<String, Boolean> overlapId(@Valid @RequestBody CheckLoginIdForm checkLoginIdForm) {
-    return userBusinessService.executeCheckId(checkLoginIdForm.loginId());
+    return userBusinessService.isDuplicatedId(checkLoginIdForm.loginId());
   }
 
-  @Monitoring(option = USER)
+  @Monitoring(target = USER)
   @PostMapping("/check-email")
   @ResponseStatus(OK)
   public Map<String, Boolean> overlapEmail(@Valid @RequestBody CheckEmailForm checkEmailForm) {
-    return userBusinessService.executeCheckEmail(checkEmailForm.email());
+    return userBusinessService.isDuplicatedEmail(checkEmailForm.email());
   }
 
-  @Monitoring(option = USER)
+  @Monitoring(target = USER)
   @PostMapping("join")
   @ResponseStatus(OK)
   public Map<String, Boolean> join(@Valid @RequestBody JoinForm joinForm) {
@@ -71,63 +73,47 @@ public class UserController {
   }
 
   // todo: confirmationControllerV2와 같은 코드
-  @Monitoring(option = USER)
+  @Monitoring(target = USER)
   @GetMapping(value = "verify-email", produces = MediaType.TEXT_HTML_VALUE + ";charset=UTF-8")
   @ResponseStatus(OK)
   public String confirmEmail(@RequestParam("token") String token) {
     return confirmationTokenBusinessService.confirmToken(token);
   }
 
-  @Monitoring(option = USER)
+  @Monitoring(target = USER)
   @PostMapping("find-id")
   @ResponseStatus(OK)
   public Map<String, Boolean> findId(@Valid @RequestBody FindIdForm findIdForm) {
-    return userBusinessService.executeFindId(findIdForm.email());
+    return userBusinessService.findId(findIdForm.email());
   }
 
-  @Monitoring(option = USER)
+  @Monitoring(target = USER)
   @PostMapping("find-pw")
   @ResponseStatus(OK)
   public Map<String, Boolean> findPw(@Valid @RequestBody FindPasswordForm findPasswordForm) {
-    return userBusinessService.executeFindPw(findPasswordForm.loginId(), findPasswordForm.email());
+    return userBusinessService.findPw(findPasswordForm.loginId(), findPasswordForm.email());
   }
 
-  @Monitoring(option = USER)
+  @Authorize
+  @Monitoring(target = USER)
   @PostMapping("reset-pw")
   @ResponseStatus(OK)
-  public Map<String, Boolean> resetPw(
-    @Valid @RequestBody EditMyPasswordForm editMyPasswordForm,
-    @RequestHeader String Authorization
-  ) {
-    return userBusinessService.executeEditPassword(
-      Authorization,
-      editMyPasswordForm.prePassword(),
-      editMyPasswordForm.newPassword()
-    );
+  public Map<String, Boolean> resetPw(@Login Long id, @Valid @RequestBody EditMyPasswordForm editMyPasswordForm) {
+    return userBusinessService.editPassword(id, editMyPasswordForm.prePassword(), editMyPasswordForm.newPassword());
   }
 
-  @Monitoring(option = USER)
+  @Monitoring(target = USER)
   @PostMapping("login")
   @ResponseStatus(OK)
-  public Map<String, String> mobileLogin(
-    @Valid @RequestBody LoginForm loginForm) {
-    return userBusinessService.executeLogin(
-      loginForm.loginId(),
-      loginForm.password()
-    );
+  public Map<String, String> mobileLogin(@Valid @RequestBody LoginForm loginForm) {
+    return userBusinessService.login(loginForm.loginId(), loginForm.password());
   }
 
-  @Monitoring(option = USER)
+  @Monitoring(target = USER)
   @PostMapping("client-login")
   @ResponseStatus(OK)
-  public Map<String, String> clientLogin(
-    @Valid @RequestBody LoginForm loginForm,
-    HttpServletResponse response
-  ) {
-    Map<String, String> tokenPair = userBusinessService.executeLogin(
-      loginForm.loginId(),
-      loginForm.password()
-    );
+  public Map<String, String> clientLogin(@Valid @RequestBody LoginForm loginForm, HttpServletResponse response) {
+    Map<String, String> tokenPair = userBusinessService.login(loginForm.loginId(), loginForm.password());
 
     Cookie refreshCookie = new Cookie("refreshToken", tokenPair.get("RefreshToken"));
     refreshCookie.setMaxAge(270 * 24 * 60 * 60);
@@ -140,26 +126,28 @@ public class UserController {
     }};
   }
 
-  @Monitoring(option = USER)
+  @Monitoring(target = USER)
   @PostMapping("client-logout")
   @ResponseStatus(OK)
   public Map<String, Boolean> clientLogout(HttpServletResponse response) {
     Cookie refreshCookie = new Cookie("refreshToken", "");
     refreshCookie.setMaxAge(0);
     response.addCookie(refreshCookie);
+
     return new HashMap<>() {{
       put("Success", true);
     }};
   }
 
-  @Monitoring(option = USER)
+  @Authorize
+  @Monitoring(target = USER)
   @GetMapping("/my-page")
   @ResponseStatus(OK)
-  public UserInformationResponseForm myPage(@Valid @RequestHeader String Authorization) {
-    return userBusinessService.executeLoadMyPage(Authorization);
+  public UserInformationResponseForm myPage(@Login Long userId) {
+    return userBusinessService.loadMyPage(userId);
   }
 
-  @Monitoring(option = USER)
+  @Monitoring(target = USER)
   @PostMapping("/client-refresh")
   @ResponseStatus(OK)
   public Map<String, String> clientTokenRefresh(
@@ -179,15 +167,14 @@ public class UserController {
     }};
   }
 
-  @Monitoring(option = USER)
+  @Monitoring(target = USER)
   @PostMapping("/refresh")
   @ResponseStatus(OK)
   public Map<String, String> tokenRefresh(@Valid @RequestHeader String Authorization) {
-    return userBusinessService.executeJWTRefreshForMobileClient(Authorization);
+    return userBusinessService.executeJWTRefreshForMobileClient(Authorization); // todo: check business logic
   }
 
-  // 회원 탈퇴
-  @Monitoring(option = USER)
+  @Monitoring(target = USER)
   @PostMapping("quit")
   @ResponseStatus(INTERNAL_SERVER_ERROR)
   public Map<String, Boolean> userQuit(
@@ -203,33 +190,34 @@ public class UserController {
     throw new AccountException(ExceptionType.SERVER_ERROR);
   }
 
-  @Monitoring(option = USER)
+  @Authorize
+  @Monitoring(target = USER)
   @PostMapping("/favorite-major")
   @ResponseStatus(OK)
-  public String saveFavoriteMajor(
-    @RequestHeader String Authorization,
-    @RequestBody FavoriteSaveDto favoriteSaveDto
-  ) {
-    userBusinessService.executeFavoriteMajorSave(Authorization, favoriteSaveDto);
+  public String saveFavoriteMajor(@Login Long userId, @Valid @RequestBody FavoriteSaveDto favoriteSaveDto) {
+    userBusinessService.saveFavoriteMajor(userId, favoriteSaveDto);
     return "success";
   }
 
-  @Monitoring(option = USER)
+  @Authorize
+  @Monitoring(target = USER)
   @DeleteMapping("/favorite-major")
   @ResponseStatus(OK)
-  public String deleteFavoriteMajor(@RequestHeader String Authorization, @RequestParam String majorType) {
-    userBusinessService.executeFavoriteMajorDelete(Authorization, majorType);
+  public String deleteFavoriteMajor(@Login Long userId, @RequestParam String majorType) {
+    userBusinessService.deleteFavoriteMajor(userId, majorType);
     return "success";
   }
 
-  @Monitoring(option = USER)
+  @Authorize
+  @Monitoring(target = USER)
   @GetMapping("/favorite-major")
   @ResponseStatus(OK)
-  public ResponseForm loadFavoriteMajor(@RequestHeader String Authorization) {
-    return userBusinessService.executeFavoriteMajorLoad(Authorization);
+  public ResponseForm loadFavoriteMajors(@Login Long userId) {
+    var response = userBusinessService.executeFavoriteMajorLoad(userId);
+    return new ResponseForm(response);
   }
 
-  @Monitoring(option = USER)
+  @Monitoring(target = USER)
   @GetMapping(value = "/suki", produces = MediaType.TEXT_HTML_VALUE + ";charset=UTF-8")
   @ResponseStatus(OK)
   public String thanksToSuwiki() {
@@ -243,17 +231,19 @@ public class UserController {
       """;
   }
 
-  @Monitoring(option = USER)
+  @Authorize
+  @Monitoring(target = USER)
   @GetMapping("/restricted-reason")
-  @ResponseStatus(OK)
-  public List<LoadMyRestrictedReasonResponseForm> loadRestrictedReason(@Valid @RequestHeader String Authorization) {
-    return userBusinessService.executeLoadRestrictedReason(Authorization);
+  @ResponseStatus(OK) // todo: RestrictingUserControllerV2 동일한 API
+  public List<LoadMyRestrictedReasonResponseForm> loadRestrictedReason(@Login Long userId) {
+    return userBusinessService.executeLoadRestrictedReason(userId);
   }
 
-  @Monitoring(option = USER)
+  @Authorize
+  @Monitoring(target = USER)
   @GetMapping("/blacklist-reason")
-  @ResponseStatus(OK)
-  public List<LoadMyBlackListReasonResponseForm> loadBlacklistReason(@Valid @RequestHeader String Authorization) {
-    return userBusinessService.executeLoadBlackListReason(Authorization);
+  @ResponseStatus(OK) // todo: BlacklistDomainControllerV2 동일한 API
+  public List<LoadMyBlackListReasonResponseForm> loadBlacklistReason(@Login Long userId) {
+    return userBusinessService.executeLoadBlackListReason(userId);
   }
 }

--- a/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/user/UserController.java
+++ b/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/user/UserController.java
@@ -15,15 +15,15 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import usw.suwiki.auth.core.annotation.Authenticated;
 import usw.suwiki.auth.core.annotation.Authorize;
-import usw.suwiki.auth.core.annotation.Login;
 import usw.suwiki.auth.token.service.ConfirmationTokenBusinessService;
 import usw.suwiki.common.response.ResponseForm;
 import usw.suwiki.core.exception.AccountException;
 import usw.suwiki.core.exception.ExceptionType;
 import usw.suwiki.domain.user.dto.FavoriteSaveDto;
 import usw.suwiki.domain.user.service.UserBusinessService;
-import usw.suwiki.statistics.annotation.Monitoring;
+import usw.suwiki.statistics.annotation.Statistics;
 
 import java.util.HashMap;
 import java.util.List;
@@ -51,21 +51,21 @@ public class UserController {
   private final UserBusinessService userBusinessService;
   private final ConfirmationTokenBusinessService confirmationTokenBusinessService;
 
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @PostMapping("/check-id")
   @ResponseStatus(OK)
   public Map<String, Boolean> overlapId(@Valid @RequestBody CheckLoginIdForm checkLoginIdForm) {
     return userBusinessService.isDuplicatedId(checkLoginIdForm.loginId());
   }
 
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @PostMapping("/check-email")
   @ResponseStatus(OK)
   public Map<String, Boolean> overlapEmail(@Valid @RequestBody CheckEmailForm checkEmailForm) {
     return userBusinessService.isDuplicatedEmail(checkEmailForm.email());
   }
 
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @PostMapping("join")
   @ResponseStatus(OK)
   public Map<String, Boolean> join(@Valid @RequestBody JoinForm joinForm) {
@@ -73,21 +73,21 @@ public class UserController {
   }
 
   // todo: confirmationControllerV2와 같은 코드
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @GetMapping(value = "verify-email", produces = MediaType.TEXT_HTML_VALUE + ";charset=UTF-8")
   @ResponseStatus(OK)
   public String confirmEmail(@RequestParam("token") String token) {
     return confirmationTokenBusinessService.confirmToken(token);
   }
 
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @PostMapping("find-id")
   @ResponseStatus(OK)
   public Map<String, Boolean> findId(@Valid @RequestBody FindIdForm findIdForm) {
     return userBusinessService.findId(findIdForm.email());
   }
 
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @PostMapping("find-pw")
   @ResponseStatus(OK)
   public Map<String, Boolean> findPw(@Valid @RequestBody FindPasswordForm findPasswordForm) {
@@ -95,21 +95,21 @@ public class UserController {
   }
 
   @Authorize
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @PostMapping("reset-pw")
   @ResponseStatus(OK)
-  public Map<String, Boolean> resetPw(@Login Long id, @Valid @RequestBody EditMyPasswordForm editMyPasswordForm) {
+  public Map<String, Boolean> resetPw(@Authenticated Long id, @Valid @RequestBody EditMyPasswordForm editMyPasswordForm) {
     return userBusinessService.editPassword(id, editMyPasswordForm.prePassword(), editMyPasswordForm.newPassword());
   }
 
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @PostMapping("login")
   @ResponseStatus(OK)
   public Map<String, String> mobileLogin(@Valid @RequestBody LoginForm loginForm) {
     return userBusinessService.login(loginForm.loginId(), loginForm.password());
   }
 
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @PostMapping("client-login")
   @ResponseStatus(OK)
   public Map<String, String> clientLogin(@Valid @RequestBody LoginForm loginForm, HttpServletResponse response) {
@@ -126,7 +126,7 @@ public class UserController {
     }};
   }
 
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @PostMapping("client-logout")
   @ResponseStatus(OK)
   public Map<String, Boolean> clientLogout(HttpServletResponse response) {
@@ -140,14 +140,14 @@ public class UserController {
   }
 
   @Authorize
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @GetMapping("/my-page")
   @ResponseStatus(OK)
-  public UserInformationResponseForm myPage(@Login Long userId) {
+  public UserInformationResponseForm myPage(@Authenticated Long userId) {
     return userBusinessService.loadMyPage(userId);
   }
 
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @PostMapping("/client-refresh")
   @ResponseStatus(OK)
   public Map<String, String> clientTokenRefresh(
@@ -167,14 +167,14 @@ public class UserController {
     }};
   }
 
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @PostMapping("/refresh")
   @ResponseStatus(OK)
   public Map<String, String> tokenRefresh(@Valid @RequestHeader String Authorization) {
     return userBusinessService.executeJWTRefreshForMobileClient(Authorization); // todo: check business logic
   }
 
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @PostMapping("quit")
   @ResponseStatus(INTERNAL_SERVER_ERROR)
   public Map<String, Boolean> userQuit(
@@ -191,33 +191,33 @@ public class UserController {
   }
 
   @Authorize
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @PostMapping("/favorite-major")
   @ResponseStatus(OK)
-  public String saveFavoriteMajor(@Login Long userId, @Valid @RequestBody FavoriteSaveDto favoriteSaveDto) {
+  public String saveFavoriteMajor(@Authenticated Long userId, @Valid @RequestBody FavoriteSaveDto favoriteSaveDto) {
     userBusinessService.saveFavoriteMajor(userId, favoriteSaveDto);
     return "success";
   }
 
   @Authorize
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @DeleteMapping("/favorite-major")
   @ResponseStatus(OK)
-  public String deleteFavoriteMajor(@Login Long userId, @RequestParam String majorType) {
+  public String deleteFavoriteMajor(@Authenticated Long userId, @RequestParam String majorType) {
     userBusinessService.deleteFavoriteMajor(userId, majorType);
     return "success";
   }
 
   @Authorize
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @GetMapping("/favorite-major")
   @ResponseStatus(OK)
-  public ResponseForm loadFavoriteMajors(@Login Long userId) {
+  public ResponseForm loadFavoriteMajors(@Authenticated Long userId) {
     var response = userBusinessService.executeFavoriteMajorLoad(userId);
     return new ResponseForm(response);
   }
 
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @GetMapping(value = "/suki", produces = MediaType.TEXT_HTML_VALUE + ";charset=UTF-8")
   @ResponseStatus(OK)
   public String thanksToSuwiki() {
@@ -232,18 +232,18 @@ public class UserController {
   }
 
   @Authorize
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @GetMapping("/restricted-reason")
   @ResponseStatus(OK) // todo: RestrictingUserControllerV2 동일한 API
-  public List<LoadMyRestrictedReasonResponseForm> loadRestrictedReason(@Login Long userId) {
+  public List<LoadMyRestrictedReasonResponseForm> loadRestrictedReason(@Authenticated Long userId) {
     return userBusinessService.executeLoadRestrictedReason(userId);
   }
 
   @Authorize
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @GetMapping("/blacklist-reason")
   @ResponseStatus(OK) // todo: BlacklistDomainControllerV2 동일한 API
-  public List<LoadMyBlackListReasonResponseForm> loadBlacklistReason(@Login Long userId) {
+  public List<LoadMyBlackListReasonResponseForm> loadBlacklistReason(@Authenticated Long userId) {
     return userBusinessService.executeLoadBlackListReason(userId);
   }
 }

--- a/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/user/UserControllerV2.java
+++ b/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/user/UserControllerV2.java
@@ -9,11 +9,11 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-import usw.suwiki.auth.core.annotation.JwtVerify;
+import usw.suwiki.auth.core.annotation.Authorize;
+import usw.suwiki.auth.core.annotation.Login;
 import usw.suwiki.common.response.ResponseForm;
 import usw.suwiki.domain.user.service.UserBusinessService;
 import usw.suwiki.statistics.annotation.Monitoring;
@@ -30,7 +30,7 @@ import static usw.suwiki.domain.user.dto.UserRequestDto.FindPasswordForm;
 import static usw.suwiki.domain.user.dto.UserRequestDto.JoinForm;
 import static usw.suwiki.domain.user.dto.UserRequestDto.LoginForm;
 import static usw.suwiki.domain.user.dto.UserRequestDto.UserQuitForm;
-import static usw.suwiki.statistics.log.MonitorOption.USER;
+import static usw.suwiki.statistics.log.MonitorTarget.USER;
 
 @RestController
 @RequestMapping("/v2/user")
@@ -38,21 +38,23 @@ import static usw.suwiki.statistics.log.MonitorOption.USER;
 public class UserControllerV2 {
   private final UserBusinessService userBusinessService;
 
-  @Monitoring(option = USER)
+  @Monitoring(target = USER)
   @PostMapping("/loginId/check")
   @ResponseStatus(OK)
   public ResponseForm overlapId(@Valid @RequestBody CheckLoginIdForm checkLoginIdForm) {
-    return ResponseForm.success(userBusinessService.executeCheckId(checkLoginIdForm.loginId()));
+    var response = userBusinessService.isDuplicatedId(checkLoginIdForm.loginId());
+    return ResponseForm.success(response);
   }
 
-  @Monitoring(option = USER)
+  @Monitoring(target = USER)
   @PostMapping("/email/check")
   @ResponseStatus(OK)
   public ResponseForm overlapEmail(@Valid @RequestBody CheckEmailForm checkEmailForm) {
-    return ResponseForm.success(userBusinessService.executeCheckEmail(checkEmailForm.email()));
+    var response = userBusinessService.isDuplicatedEmail(checkEmailForm.email());
+    return ResponseForm.success(response);
   }
 
-  @Monitoring(option = USER)
+  @Monitoring(target = USER)
   @PostMapping
   @ResponseStatus(OK)
   public ResponseForm join(@Valid @RequestBody JoinForm joinForm) {
@@ -60,58 +62,46 @@ public class UserControllerV2 {
     return ResponseForm.success(response);
   }
 
-  @Monitoring(option = USER)
+  @Monitoring(target = USER)
   @PostMapping("inquiry-loginId")
   @ResponseStatus(OK)
   public ResponseForm findId(@Valid @RequestBody FindIdForm findIdForm) {
-    return ResponseForm.success(userBusinessService.executeFindId(findIdForm.email()));
+    var response = userBusinessService.findId(findIdForm.email());
+    return ResponseForm.success(response);
   }
 
-  @Monitoring(option = USER)
+  @Monitoring(target = USER)
   @PostMapping("inquiry-password")
   @ResponseStatus(OK)
   public ResponseForm findPw(@Valid @RequestBody FindPasswordForm findPasswordForm) {
-    return ResponseForm.success(userBusinessService.executeFindPw(
-      findPasswordForm.loginId(),
-      findPasswordForm.email())
-    );
+    var response = userBusinessService.findPw(findPasswordForm.loginId(), findPasswordForm.email());
+    return ResponseForm.success(response);
   }
 
-  @Monitoring(option = USER)
+  @Authorize
+  @Monitoring(target = USER)
   @PatchMapping("password")
   @ResponseStatus(OK)
-  public ResponseForm resetPw(
-    @Valid @RequestBody EditMyPasswordForm editMyPasswordForm,
-    @RequestHeader String Authorization
-  ) {
-    return ResponseForm.success(userBusinessService.executeEditPassword(
-      Authorization,
-      editMyPasswordForm.prePassword(),
-      editMyPasswordForm.newPassword())
-    );
+  public ResponseForm resetPw(@Login Long userId, @Valid @RequestBody EditMyPasswordForm request) {
+    var response = userBusinessService.editPassword(userId, request.prePassword(), request.newPassword());
+    return ResponseForm.success(response);
   }
 
-  @Monitoring(option = USER)
+  @Monitoring(target = USER)
   @PostMapping("mobile-login")
   @ResponseStatus(OK)
-  public ResponseForm mobileLogin(@Valid @RequestBody LoginForm loginForm) {
-    return ResponseForm.success(userBusinessService.executeLogin(
-      loginForm.loginId(),
-      loginForm.password())
-    );
+  public ResponseForm mobileLogin(@Valid @RequestBody LoginForm request) {
+    return ResponseForm.success(userBusinessService.login(request.loginId(), request.password()));
   }
 
-  @Monitoring(option = USER)
+  @Monitoring(target = USER)
   @PostMapping("web-login")
   @ResponseStatus(OK)
   public ResponseForm webLogin(
     @Valid @RequestBody LoginForm loginForm,
     HttpServletResponse response
   ) {
-    Map<String, String> tokenPair = userBusinessService.executeLogin(
-      loginForm.loginId(),
-      loginForm.password()
-    );
+    Map<String, String> tokenPair = userBusinessService.login(loginForm.loginId(), loginForm.password());
 
     Cookie refreshCookie = new Cookie("refreshToken", tokenPair.get("RefreshToken"));
     refreshCookie.setMaxAge(270 * 24 * 60 * 60);
@@ -124,35 +114,34 @@ public class UserControllerV2 {
     }});
   }
 
-  @JwtVerify
-  @Monitoring(option = USER)
+  @Authorize
+  @Monitoring(target = USER)
   @PostMapping("client-logout")
   @ResponseStatus(OK)
   public ResponseForm clientLogout(HttpServletResponse response) {
     Cookie refreshCookie = new Cookie("refreshToken", "");
     refreshCookie.setMaxAge(0);
     response.addCookie(refreshCookie);
+
     return ResponseForm.success(new HashMap<>() {{
       put("Success", true);
     }});
   }
 
-  @JwtVerify
-  @Monitoring(option = USER)
+  @Authorize
+  @Monitoring(target = USER)
   @GetMapping
   @ResponseStatus(OK)
-  public ResponseForm myPage(@Valid @RequestHeader String Authorization) {
-    return ResponseForm.success(userBusinessService.executeLoadMyPage(Authorization));
+  public ResponseForm myPage(@Login Long userId) {
+    var response = userBusinessService.loadMyPage(userId);
+    return ResponseForm.success(response);
   }
 
-  @JwtVerify
-  @Monitoring(option = USER)
+  @Authorize
+  @Monitoring(target = USER)
   @DeleteMapping
   @ResponseStatus(OK)
-  public ResponseForm userQuit(
-    @Valid @RequestBody UserQuitForm userQuitForm,
-    @Valid @RequestHeader String Authorization
-  ) {
-    return ResponseForm.success(userBusinessService.executeQuit(Authorization, userQuitForm.password()));
+  public ResponseForm userQuit(@Login Long userId, @Valid @RequestBody UserQuitForm userQuitForm) {
+    return ResponseForm.success(userBusinessService.quit(userId, userQuitForm.password()));
   }
 }

--- a/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/user/UserControllerV2.java
+++ b/usw-suwiki-api/usw-suwiki-client-api/src/main/java/usw/suwiki/api/user/UserControllerV2.java
@@ -12,11 +12,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import usw.suwiki.auth.core.annotation.Authenticated;
 import usw.suwiki.auth.core.annotation.Authorize;
-import usw.suwiki.auth.core.annotation.Login;
 import usw.suwiki.common.response.ResponseForm;
 import usw.suwiki.domain.user.service.UserBusinessService;
-import usw.suwiki.statistics.annotation.Monitoring;
+import usw.suwiki.statistics.annotation.Statistics;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -38,7 +38,7 @@ import static usw.suwiki.statistics.log.MonitorTarget.USER;
 public class UserControllerV2 {
   private final UserBusinessService userBusinessService;
 
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @PostMapping("/loginId/check")
   @ResponseStatus(OK)
   public ResponseForm overlapId(@Valid @RequestBody CheckLoginIdForm checkLoginIdForm) {
@@ -46,7 +46,7 @@ public class UserControllerV2 {
     return ResponseForm.success(response);
   }
 
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @PostMapping("/email/check")
   @ResponseStatus(OK)
   public ResponseForm overlapEmail(@Valid @RequestBody CheckEmailForm checkEmailForm) {
@@ -54,7 +54,7 @@ public class UserControllerV2 {
     return ResponseForm.success(response);
   }
 
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @PostMapping
   @ResponseStatus(OK)
   public ResponseForm join(@Valid @RequestBody JoinForm joinForm) {
@@ -62,7 +62,7 @@ public class UserControllerV2 {
     return ResponseForm.success(response);
   }
 
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @PostMapping("inquiry-loginId")
   @ResponseStatus(OK)
   public ResponseForm findId(@Valid @RequestBody FindIdForm findIdForm) {
@@ -70,7 +70,7 @@ public class UserControllerV2 {
     return ResponseForm.success(response);
   }
 
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @PostMapping("inquiry-password")
   @ResponseStatus(OK)
   public ResponseForm findPw(@Valid @RequestBody FindPasswordForm findPasswordForm) {
@@ -79,22 +79,22 @@ public class UserControllerV2 {
   }
 
   @Authorize
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @PatchMapping("password")
   @ResponseStatus(OK)
-  public ResponseForm resetPw(@Login Long userId, @Valid @RequestBody EditMyPasswordForm request) {
+  public ResponseForm resetPw(@Authenticated Long userId, @Valid @RequestBody EditMyPasswordForm request) {
     var response = userBusinessService.editPassword(userId, request.prePassword(), request.newPassword());
     return ResponseForm.success(response);
   }
 
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @PostMapping("mobile-login")
   @ResponseStatus(OK)
   public ResponseForm mobileLogin(@Valid @RequestBody LoginForm request) {
     return ResponseForm.success(userBusinessService.login(request.loginId(), request.password()));
   }
 
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @PostMapping("web-login")
   @ResponseStatus(OK)
   public ResponseForm webLogin(
@@ -115,7 +115,7 @@ public class UserControllerV2 {
   }
 
   @Authorize
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @PostMapping("client-logout")
   @ResponseStatus(OK)
   public ResponseForm clientLogout(HttpServletResponse response) {
@@ -129,19 +129,19 @@ public class UserControllerV2 {
   }
 
   @Authorize
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @GetMapping
   @ResponseStatus(OK)
-  public ResponseForm myPage(@Login Long userId) {
+  public ResponseForm myPage(@Authenticated Long userId) {
     var response = userBusinessService.loadMyPage(userId);
     return ResponseForm.success(response);
   }
 
   @Authorize
-  @Monitoring(target = USER)
+  @Statistics(target = USER)
   @DeleteMapping
   @ResponseStatus(OK)
-  public ResponseForm userQuit(@Login Long userId, @Valid @RequestBody UserQuitForm userQuitForm) {
+  public ResponseForm userQuit(@Authenticated Long userId, @Valid @RequestBody UserQuitForm userQuitForm) {
     return ResponseForm.success(userBusinessService.quit(userId, userQuitForm.password()));
   }
 }

--- a/usw-suwiki-auth/build.gradle
+++ b/usw-suwiki-auth/build.gradle
@@ -6,8 +6,9 @@ subprojects {
 
 project(':usw-suwiki-auth:usw-suwiki-auth-core') {
   dependencies {
+    implementation project(':usw-suwiki-user')
+    
     implementation project(':usw-suwiki-core:usw-suwiki-secure')
-
     implementation project(':usw-suwiki-auth:usw-suwiki-auth-token')
 
     implementation('io.jsonwebtoken:jjwt-api:0.11.5')

--- a/usw-suwiki-auth/usw-suwiki-auth-core/src/main/java/usw/suwiki/auth/core/annotation/Authenticated.java
+++ b/usw-suwiki-auth/usw-suwiki-auth-core/src/main/java/usw/suwiki/auth/core/annotation/Authenticated.java
@@ -7,5 +7,5 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface Login {
+public @interface Authenticated {
 }

--- a/usw-suwiki-auth/usw-suwiki-auth-core/src/main/java/usw/suwiki/auth/core/annotation/Authorize.java
+++ b/usw-suwiki-auth/usw-suwiki-auth-core/src/main/java/usw/suwiki/auth/core/annotation/Authorize.java
@@ -1,5 +1,8 @@
 package usw.suwiki.auth.core.annotation;
 
+import org.springframework.core.annotation.AliasFor;
+import usw.suwiki.domain.user.Role;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -7,7 +10,10 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface JwtVerify {
+public @interface Authorize {
+  @AliasFor("role")
+  Role value() default Role.USER;
 
-  String option() default "";
+  @AliasFor("value")
+  Role role() default Role.USER;
 }

--- a/usw-suwiki-auth/usw-suwiki-auth-core/src/main/java/usw/suwiki/auth/core/annotation/Login.java
+++ b/usw-suwiki-auth/usw-suwiki-auth-core/src/main/java/usw/suwiki/auth/core/annotation/Login.java
@@ -1,14 +1,11 @@
-package usw.suwiki.statistics.annotation;
-
-import usw.suwiki.statistics.log.MonitorTarget;
+package usw.suwiki.auth.core.annotation;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target(ElementType.METHOD)
+@Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface Monitoring {
-  MonitorTarget target();
+public @interface Login {
 }

--- a/usw-suwiki-auth/usw-suwiki-auth-core/src/main/java/usw/suwiki/auth/core/common/CustomUserDetailsService.java
+++ b/usw-suwiki-auth/usw-suwiki-auth-core/src/main/java/usw/suwiki/auth/core/common/CustomUserDetailsService.java
@@ -1,0 +1,33 @@
+package usw.suwiki.auth.core.common;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+import usw.suwiki.domain.user.model.UserAdapter;
+import usw.suwiki.domain.user.service.UserAdapterService;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+  private final UserAdapterService userAdapterService;
+
+  @Override
+  public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+    var userAdapter = userAdapterService.findByUsername(username);
+    return toDetails(userAdapter);
+  }
+
+  private UserDetails toDetails(UserAdapter userAdapter) {
+    return new User(
+      String.valueOf(userAdapter.id()),
+      null,
+      List.of(new SimpleGrantedAuthority(userAdapter.role().name()))
+    );
+  }
+}

--- a/usw-suwiki-auth/usw-suwiki-auth-core/src/main/java/usw/suwiki/auth/core/common/CustomUserDetailsService.java
+++ b/usw-suwiki-auth/usw-suwiki-auth-core/src/main/java/usw/suwiki/auth/core/common/CustomUserDetailsService.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 @Component
 @RequiredArgsConstructor
-public class CustomUserDetailsService implements UserDetailsService {
+class CustomUserDetailsService implements UserDetailsService {
   private final UserAdapterService userAdapterService;
 
   @Override

--- a/usw-suwiki-auth/usw-suwiki-auth-core/src/main/java/usw/suwiki/auth/core/config/SecurityConfig.java
+++ b/usw-suwiki-auth/usw-suwiki-auth-core/src/main/java/usw/suwiki/auth/core/config/SecurityConfig.java
@@ -1,9 +1,8 @@
 package usw.suwiki.auth.core.config;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -11,8 +10,7 @@ import org.springframework.security.web.SecurityFilterChain;
 
 import static org.springframework.security.config.Customizer.withDefaults;
 
-@EnableWebSecurity
-@RequiredArgsConstructor
+@Configuration
 public class SecurityConfig {
 
   private static final String[] PERMIT_URL_ARRAY = {

--- a/usw-suwiki-auth/usw-suwiki-auth-core/src/main/java/usw/suwiki/auth/core/config/WebMvcConfig.java
+++ b/usw-suwiki-auth/usw-suwiki-auth-core/src/main/java/usw/suwiki/auth/core/config/WebMvcConfig.java
@@ -2,14 +2,18 @@ package usw.suwiki.auth.core.config;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import usw.suwiki.auth.core.interceptor.JwtInterceptor;
+import usw.suwiki.auth.core.resolver.AuthenticatedUserArgumentResolver;
+
+import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {
-
+  private final AuthenticatedUserArgumentResolver authenticatedUserArgumentResolver;
   private final JwtInterceptor jwtInterceptor;
 
   @Override
@@ -23,5 +27,10 @@ public class WebMvcConfig implements WebMvcConfigurer {
       .excludePathPatterns("/swagger-ui.html")
       .excludePathPatterns("/webjars/**")
       .addPathPatterns("/**");
+  }
+
+  @Override
+  public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+    resolvers.add(authenticatedUserArgumentResolver);
   }
 }

--- a/usw-suwiki-auth/usw-suwiki-auth-core/src/main/java/usw/suwiki/auth/core/jwt/JwtAgent.java
+++ b/usw-suwiki-auth/usw-suwiki-auth-core/src/main/java/usw/suwiki/auth/core/jwt/JwtAgent.java
@@ -3,8 +3,11 @@ package usw.suwiki.auth.core.jwt;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import usw.suwiki.auth.core.common.CustomUserDetailsService;
 import usw.suwiki.auth.token.RefreshToken;
 import usw.suwiki.auth.token.service.RefreshTokenService;
 import usw.suwiki.core.exception.AccountException;
@@ -15,12 +18,31 @@ import usw.suwiki.core.secure.model.Claim;
 import java.util.Map;
 import java.util.Optional;
 
+import static java.lang.Boolean.TRUE;
+import static usw.suwiki.auth.core.jwt.RawParser.Content;
+import static usw.suwiki.domain.user.Role.ADMIN;
+
 @Component
 @RequiredArgsConstructor
-class JwtAgent implements TokenAgent {
+public class JwtAgent implements TokenAgent { // todo: public 이지만 외부로 노출을 감출 것.
   private final RefreshTokenService refreshTokenService;
+
+  private final CustomUserDetailsService userDetailsService;
   private final JwtSecretProvider jwtSecretProvider;
   private final RawParser rawParser;
+
+  public Authentication parseAuthentication(String token) {
+    validateRestricted(token);
+    var loginId = rawParser.parse(token, Content.LOGIN_ID, String.class);
+    var userDetails = userDetailsService.loadUserByUsername(loginId);
+    return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+  }
+
+  private void validateRestricted(String token) {
+    if (TRUE.equals(rawParser.parse(token, Content.RESTRICTED, Boolean.class))) {
+      throw new AccountException(ExceptionType.USER_RESTRICTED);
+    }
+  }
 
   @Transactional
   @Override
@@ -58,11 +80,6 @@ class JwtAgent implements TokenAgent {
   }
 
   @Override
-  public void validateJwt(String token) { // todo: 인터셉터 개편 후 삭제 예정, 호출될 일 없게 만들기
-    rawParser.validate(token);
-  }
-
-  @Override
   public String createAccessToken(Long userId, Claim claim) {
     Claims claims = Jwts.claims().setSubject(claim.loginId());
     claims.putAll(Map.of("id", userId, "loginId", claim.loginId(), "role", claim.role(), "restricted", claim.restricted()));
@@ -75,20 +92,11 @@ class JwtAgent implements TokenAgent {
       .compact();
   }
 
-  @Override
-  public Long parseId(String token) {
-    return rawParser.parse(token, RawParser.Content.ID, Long.class);
-  }
-
-  @Override
   public String parseRole(String token) {
-    return rawParser.parse(token, RawParser.Content.ROLE, String.class);
+    return rawParser.parse(token, Content.ROLE, String.class);
   }
 
-  @Override
-  public void validateRestrictedUser(String token) {
-    if (Boolean.TRUE.equals(rawParser.parse(token, RawParser.Content.RESTRICTED, Boolean.class))) {
-      throw new AccountException(ExceptionType.USER_RESTRICTED);
-    }
+  public boolean isNotAdmin(String token) {
+    return token != null && ADMIN.isAdmin(parseRole(token));
   }
 }

--- a/usw-suwiki-auth/usw-suwiki-auth-core/src/main/java/usw/suwiki/auth/core/jwt/JwtAgent.java
+++ b/usw-suwiki-auth/usw-suwiki-auth-core/src/main/java/usw/suwiki/auth/core/jwt/JwtAgent.java
@@ -5,9 +5,9 @@ import io.jsonwebtoken.Jwts;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-import usw.suwiki.auth.core.common.CustomUserDetailsService;
 import usw.suwiki.auth.token.RefreshToken;
 import usw.suwiki.auth.token.service.RefreshTokenService;
 import usw.suwiki.core.exception.AccountException;
@@ -27,7 +27,7 @@ import static usw.suwiki.domain.user.Role.ADMIN;
 public class JwtAgent implements TokenAgent { // todo: public 이지만 외부로 노출을 감출 것.
   private final RefreshTokenService refreshTokenService;
 
-  private final CustomUserDetailsService userDetailsService;
+  private final UserDetailsService userDetailsService;
   private final JwtSecretProvider jwtSecretProvider;
   private final RawParser rawParser;
 

--- a/usw-suwiki-auth/usw-suwiki-auth-core/src/main/java/usw/suwiki/auth/core/jwt/RawParser.java
+++ b/usw-suwiki-auth/usw-suwiki-auth-core/src/main/java/usw/suwiki/auth/core/jwt/RawParser.java
@@ -17,7 +17,7 @@ import static usw.suwiki.core.exception.ExceptionType.TOKEN_IS_EXPIRED;
 @Component
 class RawParser {
   enum Content {
-    ID, ROLE, RESTRICTED;
+    ID, LOGIN_ID, ROLE, RESTRICTED;
   }
 
   private final JwtParser parser;

--- a/usw-suwiki-auth/usw-suwiki-auth-core/src/main/java/usw/suwiki/auth/core/resolver/AuthenticatedUserArgumentResolver.java
+++ b/usw-suwiki-auth/usw-suwiki-auth-core/src/main/java/usw/suwiki/auth/core/resolver/AuthenticatedUserArgumentResolver.java
@@ -8,8 +8,8 @@ import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
+import usw.suwiki.auth.core.annotation.Authenticated;
 import usw.suwiki.auth.core.annotation.Authorize;
-import usw.suwiki.auth.core.annotation.Login;
 import usw.suwiki.core.exception.BaseException;
 import usw.suwiki.core.exception.ExceptionType;
 
@@ -21,7 +21,7 @@ public class AuthenticatedUserArgumentResolver implements HandlerMethodArgumentR
 
   @Override
   public boolean supportsParameter(MethodParameter parameter) {
-    return parameter.getParameterType().equals(Long.class) && parameter.hasParameterAnnotation(Login.class);
+    return parameter.getParameterType().equals(Long.class) && parameter.hasParameterAnnotation(Authenticated.class);
   }
 
   @Override

--- a/usw-suwiki-auth/usw-suwiki-auth-core/src/main/java/usw/suwiki/auth/core/resolver/AuthenticatedUserArgumentResolver.java
+++ b/usw-suwiki-auth/usw-suwiki-auth-core/src/main/java/usw/suwiki/auth/core/resolver/AuthenticatedUserArgumentResolver.java
@@ -1,0 +1,51 @@
+package usw.suwiki.auth.core.resolver;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import usw.suwiki.auth.core.annotation.Authorize;
+import usw.suwiki.auth.core.annotation.Login;
+import usw.suwiki.core.exception.BaseException;
+import usw.suwiki.core.exception.ExceptionType;
+
+import java.lang.reflect.Method;
+import java.util.Objects;
+
+@Component
+public class AuthenticatedUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+  @Override
+  public boolean supportsParameter(MethodParameter parameter) {
+    return parameter.getParameterType().equals(Long.class) && parameter.hasParameterAnnotation(Login.class);
+  }
+
+  @Override
+  public Long resolveArgument(
+    MethodParameter parameter,
+    ModelAndViewContainer mavContainer,
+    NativeWebRequest webRequest,
+    WebDataBinderFactory binderFactory
+  ) {
+    validateAuthorization(parameter);
+    return resolveIdFromContext();
+  }
+
+  private void validateAuthorization(MethodParameter parameter) {
+    Method method = Objects.requireNonNull(parameter.getMethod());
+
+    if (method.getAnnotation(Authorize.class) == null) {
+      throw new BaseException(ExceptionType.AUTHORIZATION_NOT_PROCESSED);
+    }
+  }
+
+  private Long resolveIdFromContext() {
+    var authentication = SecurityContextHolder.getContext().getAuthentication();
+    var principal = (User) authentication.getPrincipal();
+    return Long.parseLong(principal.getUsername()); // username : 사용자의 ID 값
+  }
+}

--- a/usw-suwiki-auth/usw-suwiki-auth-core/src/main/resources/application-secrets.yml
+++ b/usw-suwiki-auth/usw-suwiki-auth-core/src/main/resources/application-secrets.yml
@@ -7,4 +7,3 @@ jwt:
 
 jasypt:
   password: ${JASYPT_PASSWORD}
-

--- a/usw-suwiki-core/usw-suwiki-exception/src/main/java/usw/suwiki/core/exception/ExceptionType.java
+++ b/usw-suwiki-core/usw-suwiki-exception/src/main/java/usw/suwiki/core/exception/ExceptionType.java
@@ -131,6 +131,7 @@ public enum ExceptionType {
   HTTP_METHOD_NOT_ALLOWED("CLIENT002", "해당 HTTP 메서드는 제공하지 않습니다.", METHOD_NOT_ALLOWED),
   INVALID_REQUEST_BODY("CLIENT003", "요청 바디가 유효하지 않습니다.", BAD_REQUEST),
   INVALID_REQUEST_PARAM("CLIENT004", "요청 파라미터가 유효하지 않습니다.", BAD_REQUEST),
+  AUTHORIZATION_NOT_PROCESSED("CLIENT005", "인증을 진행하지 않았습니다.", BAD_REQUEST),
 
   ;
 

--- a/usw-suwiki-core/usw-suwiki-secure/src/main/java/usw/suwiki/core/secure/TokenAgent.java
+++ b/usw-suwiki-core/usw-suwiki-secure/src/main/java/usw/suwiki/core/secure/TokenAgent.java
@@ -7,13 +7,5 @@ public interface TokenAgent {
 
   String reissue(String payload);
 
-  void validateJwt(String token);
-
   String createAccessToken(Long userId, Claim claim);
-
-  Long parseId(String token);
-
-  String parseRole(String token);
-
-  void validateRestrictedUser(String token);
 }

--- a/usw-suwiki-lecture/build.gradle
+++ b/usw-suwiki-lecture/build.gradle
@@ -33,6 +33,5 @@ project(':usw-suwiki-lecture:usw-suwiki-timetable') {
 project(':usw-suwiki-lecture:usw-suwiki-major') {
   dependencies {
     implementation project(':usw-suwiki-user')
-    implementation project(':usw-suwiki-core:usw-suwiki-secure') // todo: 코드 개선하면 삭제가능할듯
   }
 }

--- a/usw-suwiki-lecture/usw-suwiki-major/src/main/java/usw/suwiki/domain/lecture/major/service/FavoriteMajorServiceV2.java
+++ b/usw-suwiki-lecture/usw-suwiki-major/src/main/java/usw/suwiki/domain/lecture/major/service/FavoriteMajorServiceV2.java
@@ -5,7 +5,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import usw.suwiki.core.exception.ExceptionType;
 import usw.suwiki.core.exception.FavoriteMajorException;
-import usw.suwiki.core.secure.TokenAgent;
 import usw.suwiki.domain.lecture.major.FavoriteMajor;
 import usw.suwiki.domain.lecture.major.FavoriteMajorRepositoryV2;
 
@@ -17,14 +16,8 @@ import java.util.List;
 public class FavoriteMajorServiceV2 {
   private final FavoriteMajorRepositoryV2 favoriteMajorRepositoryV2;
 
-  private final TokenAgent tokenAgent;
-
-  public void save(String authorization, String majorType) {
-    tokenAgent.validateRestrictedUser(authorization);
-    Long userId = tokenAgent.parseId(authorization);
-
+  public void save(Long userId, String majorType) {
     validateDuplicateFavoriteMajor(userId, majorType);
-
     favoriteMajorRepositoryV2.save(new FavoriteMajor(userId, majorType));
   }
 
@@ -34,18 +27,12 @@ public class FavoriteMajorServiceV2 {
     }
   }
 
-  public List<String> findAllMajorTypeByUser(String authorization) {
-    tokenAgent.validateRestrictedUser(authorization);
-    Long userId = tokenAgent.parseId(authorization);
-
+  public List<String> findAllMajorTypeByUser(Long userId) {
     List<FavoriteMajor> favoriteMajors = favoriteMajorRepositoryV2.findAllByUserIdx(userId);
     return favoriteMajors.stream().map(FavoriteMajor::getMajorType).toList();
   }
 
-  public void delete(String authorization, String majorType) {
-    tokenAgent.validateRestrictedUser(authorization);
-    Long userId = tokenAgent.parseId(authorization);
-
+  public void delete(Long userId, String majorType) {
     FavoriteMajor favoriteMajor = favoriteMajorRepositoryV2.findByUserIdxAndMajorType(userId, majorType)
       .orElseThrow(() -> new FavoriteMajorException(ExceptionType.FAVORITE_MAJOR_NOT_FOUND));
 

--- a/usw-suwiki-statistics/src/main/java/usw/suwiki/statistics/annotation/Statistics.java
+++ b/usw-suwiki-statistics/src/main/java/usw/suwiki/statistics/annotation/Statistics.java
@@ -9,6 +9,6 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface Monitoring {
+public @interface Statistics {
   MonitorTarget target();
 }

--- a/usw-suwiki-statistics/src/main/java/usw/suwiki/statistics/aspect/MonitoringAspect.java
+++ b/usw-suwiki-statistics/src/main/java/usw/suwiki/statistics/aspect/MonitoringAspect.java
@@ -37,7 +37,7 @@ public class MonitoringAspect {
       LocalDateTime end = LocalDateTime.now();
       log.info("{} Api Start = {}, End = {}", request.getRequestURI(), start, end);
 
-      apiLoggerService.logApi(monitoring.option(), Duration.between(start, end).toMillis());
+      apiLoggerService.logApi(monitoring.target(), Duration.between(start, end).toMillis());
     }
   }
 

--- a/usw-suwiki-statistics/src/main/java/usw/suwiki/statistics/aspect/MonitoringAspect.java
+++ b/usw-suwiki-statistics/src/main/java/usw/suwiki/statistics/aspect/MonitoringAspect.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 import usw.suwiki.statistics.annotation.AppProfile;
-import usw.suwiki.statistics.annotation.Monitoring;
+import usw.suwiki.statistics.annotation.Statistics;
 import usw.suwiki.statistics.log.ApiLoggerService;
 
 import java.time.Duration;
@@ -25,8 +25,8 @@ import java.util.Objects;
 public class MonitoringAspect {
   private final ApiLoggerService apiLoggerService;
 
-  @Around("@annotation(usw.suwiki.statistics.annotation.Monitoring) && @annotation(monitoring)")
-  public Object monitor(ProceedingJoinPoint joinPoint, Monitoring monitoring) throws Throwable {
+  @Around("@annotation(usw.suwiki.statistics.annotation.Statistics) && @annotation(statistics)")
+  public Object monitor(ProceedingJoinPoint joinPoint, Statistics statistics) throws Throwable {
     LocalDateTime start = LocalDateTime.now();
 
     try {
@@ -37,7 +37,7 @@ public class MonitoringAspect {
       LocalDateTime end = LocalDateTime.now();
       log.info("{} Api Start = {}, End = {}", request.getRequestURI(), start, end);
 
-      apiLoggerService.logApi(monitoring.target(), Duration.between(start, end).toMillis());
+      apiLoggerService.logApi(statistics.target(), Duration.between(start, end).toMillis());
     }
   }
 

--- a/usw-suwiki-statistics/src/main/java/usw/suwiki/statistics/log/ApiLoggerService.java
+++ b/usw-suwiki-statistics/src/main/java/usw/suwiki/statistics/log/ApiLoggerService.java
@@ -19,7 +19,7 @@ public class ApiLoggerService {
 
   @Async
   @Transactional
-  public void logApi(MonitorOption option, Long processTime) {
+  public void logApi(MonitorTarget option, Long processTime) {
     Optional<ApiLogger> apiLogger = apiLoggerRepository.findByCallDate(LocalDate.now());
 
     if (apiLogger.isEmpty()) {
@@ -34,7 +34,7 @@ public class ApiLoggerService {
     apiLoggerRepository.save(oldApiStatistics(apiLogger.get(), option, processTime));
   }
 
-  private ApiLogger newApiStatistics(MonitorOption option, Long processTime) {
+  private ApiLogger newApiStatistics(MonitorTarget option, Long processTime) {
     return switch (option) {
       case LECTURE -> ApiLogger.lecture(processTime);
       case EVALUATE_POSTS -> ApiLogger.evaluate(processTime);
@@ -45,7 +45,7 @@ public class ApiLoggerService {
     };
   }
 
-  private ApiLogger oldApiStatistics(ApiLogger apiLogger, MonitorOption option, Long processTime) {
+  private ApiLogger oldApiStatistics(ApiLogger apiLogger, MonitorTarget option, Long processTime) {
     return switch (option) {
       case LECTURE -> apiLogger.logLecture(processTime);
       case EVALUATE_POSTS -> apiLogger.logEvaluatePosts(processTime);

--- a/usw-suwiki-statistics/src/main/java/usw/suwiki/statistics/log/MonitorTarget.java
+++ b/usw-suwiki-statistics/src/main/java/usw/suwiki/statistics/log/MonitorTarget.java
@@ -2,7 +2,7 @@ package usw.suwiki.statistics.log;
 
 import static java.lang.Character.toUpperCase;
 
-public enum MonitorOption {
+public enum MonitorTarget {
   LECTURE,
   EVALUATE_POSTS,
   EXAM_POSTS,

--- a/usw-suwiki-user/build.gradle
+++ b/usw-suwiki-user/build.gradle
@@ -1,7 +1,7 @@
 allprojects {
   dependencies {
     implementation project(':usw-suwiki-core:usw-suwiki-exception')
-    implementation project(':usw-suwiki-core:usw-suwiki-secure')
+    implementation project(':usw-suwiki-core:usw-suwiki-secure') // todo: presentation layer로 모든 책임을 옮기고 삭제
     implementation project(':usw-suwiki-infra:usw-suwiki-db')
     implementation project(':usw-suwiki-common')
 

--- a/usw-suwiki-user/src/main/java/usw/suwiki/domain/user/Role.java
+++ b/usw-suwiki-user/src/main/java/usw/suwiki/domain/user/Role.java
@@ -7,9 +7,17 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum Role {
 
-    ADMIN("ADMIN", "관리자 권한"),
-    USER("USER", "사용자 권한");
+  ADMIN("ADMIN", "관리자 권한"),
+  USER("USER", "사용자 권한");
 
-    private final String key;
-    private final String title;
+  private final String key;
+  private final String title;
+
+  public boolean isAdmin() {
+    return this.equals(ADMIN);
+  }
+
+  public boolean isAdmin(String key) {
+    return ADMIN.key.equals(key.toUpperCase());
+  }
 }

--- a/usw-suwiki-user/src/main/java/usw/suwiki/domain/user/dto/UserResponseDto.java
+++ b/usw-suwiki-user/src/main/java/usw/suwiki/domain/user/dto/UserResponseDto.java
@@ -8,46 +8,46 @@ import java.time.LocalDateTime;
 
 public final class UserResponseDto {
 
-    @Builder
-    public record UserInformationResponseForm(
-        String loginId,
-        String email,
-        Integer point,
-        Integer writtenEvaluation,
-        Integer writtenExam,
-        Integer viewExam
-    ) {
-        public static UserInformationResponseForm buildMyPageResponseForm(User user) {
-            return builder()
-                .loginId(user.getLoginId())
-                .email(user.getEmail())
-                .point(user.getPoint())
-                .writtenEvaluation(user.getWrittenEvaluation())
-                .writtenExam(user.getWrittenExam())
-                .viewExam(user.getViewExamCount())
-                .build();
-        }
+  @Builder
+  public record UserInformationResponseForm(
+    String loginId,
+    String email,
+    Integer point,
+    Integer writtenEvaluation,
+    Integer writtenExam,
+    Integer viewExam
+  ) {
+    public static UserInformationResponseForm toMyPageResponse(User user) {
+      return builder()
+        .loginId(user.getLoginId())
+        .email(user.getEmail())
+        .point(user.getPoint())
+        .writtenEvaluation(user.getWrittenEvaluation())
+        .writtenExam(user.getWrittenExam())
+        .viewExam(user.getViewExamCount())
+        .build();
     }
+  }
 
-    @Builder
-    public record LoadMyRestrictedReasonResponseForm(
-        String restrictedReason,
-        String judgement,
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
-        LocalDateTime createdAt,
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
-        LocalDateTime restrictingDate
-    ) {
-    }
+  @Builder
+  public record LoadMyRestrictedReasonResponseForm(
+    String restrictedReason,
+    String judgement,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+    LocalDateTime createdAt,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+    LocalDateTime restrictingDate
+  ) {
+  }
 
-    @Builder
-    public record LoadMyBlackListReasonResponseForm(
-        String blackListReason,
-        String judgement,
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
-        LocalDateTime createdAt,
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
-        LocalDateTime expiredAt
-    ) {
-    }
+  @Builder
+  public record LoadMyBlackListReasonResponseForm(
+    String blackListReason,
+    String judgement,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+    LocalDateTime createdAt,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+    LocalDateTime expiredAt
+  ) {
+  }
 }

--- a/usw-suwiki-user/src/main/java/usw/suwiki/domain/user/model/UserAdapter.java
+++ b/usw-suwiki-user/src/main/java/usw/suwiki/domain/user/model/UserAdapter.java
@@ -1,0 +1,14 @@
+package usw.suwiki.domain.user.model;
+
+import usw.suwiki.domain.user.Role;
+import usw.suwiki.domain.user.User;
+
+public record UserAdapter(
+  Long id,
+  String loginId,
+  Role role
+) {
+  public static UserAdapter from(User user) {
+    return new UserAdapter(user.getId(), user.getLoginId(), user.getRole());
+  }
+}

--- a/usw-suwiki-user/src/main/java/usw/suwiki/domain/user/service/UserAdapterService.java
+++ b/usw-suwiki-user/src/main/java/usw/suwiki/domain/user/service/UserAdapterService.java
@@ -1,0 +1,7 @@
+package usw.suwiki.domain.user.service;
+
+import usw.suwiki.domain.user.model.UserAdapter;
+
+public interface UserAdapterService {
+  UserAdapter findByUsername(String username);
+}

--- a/usw-suwiki-user/src/main/java/usw/suwiki/domain/user/service/UserCRUDService.java
+++ b/usw-suwiki-user/src/main/java/usw/suwiki/domain/user/service/UserCRUDService.java
@@ -7,6 +7,7 @@ import usw.suwiki.core.exception.AccountException;
 import usw.suwiki.core.exception.ExceptionType;
 import usw.suwiki.domain.user.User;
 import usw.suwiki.domain.user.UserRepository;
+import usw.suwiki.domain.user.model.UserAdapter;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -15,7 +16,7 @@ import java.util.Optional;
 @Service
 @Transactional
 @RequiredArgsConstructor
-public class UserCRUDService {
+public class UserCRUDService implements UserAdapterService {
   private final UserRepository userRepository;
 
   public void saveUser(User user) {
@@ -62,10 +63,7 @@ public class UserCRUDService {
   }
 
   private User convertOptionalUserToDomainUser(Optional<User> optionalUser) {
-    if (optionalUser.isPresent()) {
-      return optionalUser.get();
-    }
-    throw new AccountException(ExceptionType.USER_NOT_EXISTS);
+    return optionalUser.orElseThrow(() -> new AccountException(ExceptionType.USER_NOT_EXISTS));
   }
 
   @Transactional(readOnly = true)
@@ -80,5 +78,12 @@ public class UserCRUDService {
   public void softDeleteForIsolation(Long userIdx) {
     User user = loadUserById(userIdx);
     user.sleep();
+  }
+
+  @Override
+  public UserAdapter findByUsername(String username) {
+    return userRepository.findByLoginId(username)
+      .map(UserAdapter::from)
+      .orElseThrow(() -> new AccountException(ExceptionType.USER_NOT_FOUND));
   }
 }


### PR DESCRIPTION
## 🙋 어떤 PR인가요?
기존에 퍼져있던 토큰 검증 로직을 스프링을 적극 사용해서 개선하였습니다.

## 📝 작업 상세

### 1. 토큰 검증 추상화
기존에 `JwtAgent`가 모든 컨트롤러에 위치해서 제한된 유저인지 검증했습니다.
presentation layer의 핵심 관심사이나 **너무 많은 중복된 코드가 발생하여 interceptor에서 처리하도록 수정**하였습니다.

Controller에 다음과 같이 어노테이션이 붙어있다면 앞으로 **헤더에 토큰을 넣어줘야함(인증이 수반되어야함)을 의미**합니다.
```java
@Authorize
public ApiResponse<?> someApi() {
   // logic...
}
```

또한, 관리자 API에 대해서는 다음과 같이 사용하면 **관리자의 토큰이 아닐 때 예외 응답**합니다.
```java
@Authorize(Role.ADMIN)
public ApiResponse<?> someAdminApi() {
   // logic...
}
```

권한을 모듈 별로 따로 만들지 않고 **기존 것을 사용하는게 추후 확장에 따라 발생할 수 있는 휴면 에러를 방지할 수 있다고 판단**하였습니다.
그로 인해서 **인증 core에서 사용자 모듈로 의존성이 추가**되었습니다.

### 2. 유저 ID 파싱 추상화
1번과 비슷한 맥락으로 `JwtAgent`가 각 컨트롤러에 퍼져있거나, 서비스 계층까지 침투하고 있었습니다.
이런 현상을 방지하고자 `AuthenticatedUserArgumentResolver`을 도입해 **중복된 코드를 줄이고 한 지점에서 관리할 수 있도록 하였습니다**.

앞서 설명한 `@Authorize` **어노테이션 없이 사용할 시에 인증이 완료되지 않아 예외를 반환**합니다. 사용법은 다음과 같습니다.
```java
@Authorize
public ApiResponse<?> someApi(@Login Long userId) {
   // logic...
}
```

### 3. 과한 책임의 TokenAgent 개선
기존 TokenAgent는 너무 많은 책임을 담당하고 있었기 때문에 필요없는 책임은 모두 없앴습니다.
실질적인 구현체인 `JwtAgent`는 모듈을 auth-core에서 auth-token 쪽으로 이동시켜서 내부적으로 사용되고 외부는 TokenAgent로만 노출을 할 수 있도록 정보 은닉을 진행할 예정입니다.

## 🙏 To Reviewers
- 유저 정보를 불러오기 위해서 UserDetailsService를 추가하였습니다. 모듈 구조로 인해서 어쩔 수 없이 user 모듈 쪽에 추가적인 클래스가 반영되었습니다. 이 부분은 추후 개선해보겠습니다~
- 적용되지 않던 security 설정이 반영되었습니다. 이로 인해서 **테스트 시 문제가 발생할 수 있으니 참고바랍니다!**

## 🧐 체크리스트

- [x]  본인을 Assign해주시고, 본인을 제외한 백엔드 개발자를 Reviewer로 지정해주세요.
- [x]  라벨 체크해주세요.
- [x]  .yml 파일 수정 내용이 있다면 공유해주세요!
- [x]  정상동작하는지, 테스트 통과하는지 다시 한번 확인해주세요.
